### PR TITLE
Fix Android fullscreen black area and viewport sizing

### DIFF
--- a/ladxhd_game_source_code/Directory.Build.props
+++ b/ladxhd_game_source_code/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <CheckEolWorkloads>false</CheckEolWorkloads>
+  </PropertyGroup>
+</Project>

--- a/ladxhd_game_source_code/ProjectZ.Android/AndroidActivity.cs
+++ b/ladxhd_game_source_code/ProjectZ.Android/AndroidActivity.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.App;
 using Android.Content.PM;
 using Android.Content.Res;
@@ -24,12 +25,16 @@ namespace ProjectZ.Android
     {
         protected override void OnCreate(Bundle? savedInstanceState)
         {
-            Window.AddFlags(WindowManagerFlags.Fullscreen);
-            Window.AddFlags(WindowManagerFlags.LayoutNoLimits);
-            Window.ClearFlags(WindowManagerFlags.ForceNotFullscreen);
+            var window = Window;
+            if (window != null)
+            {
+                window.AddFlags(WindowManagerFlags.Fullscreen);
+                window.AddFlags(WindowManagerFlags.LayoutNoLimits);
+                window.ClearFlags(WindowManagerFlags.ForceNotFullscreen);
 
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
-                Window.Attributes.LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
+                if (OperatingSystem.IsAndroidVersionAtLeast(28) && window.Attributes is { } attributes)
+                    attributes.LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
+            }
 
             base.OnCreate(savedInstanceState);
 
@@ -44,6 +49,46 @@ namespace ProjectZ.Android
             System.IO.Directory.CreateDirectory(Values.PathGraphicsMods);
             System.IO.Directory.CreateDirectory(Values.PathSaveFolder);
 
+            // Get real display size for proper fullscreen rendering.
+            var surfaceWidth = 0;
+            var surfaceHeight = 0;
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(30))
+            {
+                var metrics = WindowManager?.CurrentWindowMetrics;
+                var bounds = metrics?.Bounds;
+                if (bounds != null)
+                {
+                    surfaceWidth = bounds.Width();
+                    surfaceHeight = bounds.Height();
+                }
+            }
+            else
+            {
+                var display = WindowManager?.DefaultDisplay;
+                if (display != null)
+                {
+                    var size = new global::Android.Graphics.Point();
+#pragma warning disable CS0618
+                    display.GetRealSize(size);
+#pragma warning restore CS0618
+                    surfaceWidth = size.X;
+                    surfaceHeight = size.Y;
+                }
+            }
+
+            if (surfaceWidth > 0 && surfaceHeight > 0)
+            {
+                // Ensure landscape orientation (wider dimension first).
+                if (surfaceWidth < surfaceHeight)
+                {
+                    var swap = surfaceWidth;
+                    surfaceWidth = surfaceHeight;
+                    surfaceHeight = swap;
+                }
+                Game1.SetAndroidSurfaceSizeHint(surfaceWidth, surfaceHeight);
+            }
+
             // construct your real game here:
             var game = new Game1(
                 editorMode: false,
@@ -53,7 +98,11 @@ namespace ProjectZ.Android
             game.Services.AddService(typeof(AssetManager), Assets);
 
             var view = (View)game.Services.GetService(typeof(View))!;
-            SetContentView(view);
+            var matchParent = new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MatchParent,
+                ViewGroup.LayoutParams.MatchParent);
+            view.LayoutParameters = matchParent;
+            SetContentView(view, matchParent);
 
             ApplyFullscreenFlags();
 
@@ -65,10 +114,14 @@ namespace ProjectZ.Android
 
         private void ApplyFullscreenFlags()
         {
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.R)
+            var window = Window;
+            if (window == null)
+                return;
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(30))
             {
-                Window.SetDecorFitsSystemWindows(false);
-                var controller = Window.InsetsController;
+                window.SetDecorFitsSystemWindows(false);
+                var controller = window.InsetsController;
                 if (controller != null)
                 {
                     controller.Hide(global::Android.Views.WindowInsets.Type.StatusBars() |
@@ -79,7 +132,12 @@ namespace ProjectZ.Android
             }
             else
             {
-                Window.DecorView.SystemUiVisibility =
+                var decorView = window.DecorView;
+                if (decorView == null)
+                    return;
+
+#pragma warning disable CS0618
+                decorView.SystemUiVisibility =
                     (StatusBarVisibility)(
                         SystemUiFlags.LayoutStable |
                         SystemUiFlags.LayoutHideNavigation |
@@ -87,6 +145,7 @@ namespace ProjectZ.Android
                         SystemUiFlags.HideNavigation |
                         SystemUiFlags.Fullscreen |
                         SystemUiFlags.ImmersiveSticky);
+#pragma warning restore CS0618
             }
         }
 
@@ -97,8 +156,11 @@ namespace ProjectZ.Android
                 ApplyFullscreenFlags();
         }
 
-        public override bool DispatchKeyEvent(KeyEvent e)
+        public override bool DispatchKeyEvent(KeyEvent? e)
         {
+            if (e == null)
+                return base.DispatchKeyEvent(e);
+
             // Only treat "down" as a press (avoid repeats).
             if (e.Action == KeyEventActions.Down && e.RepeatCount == 0)
             {

--- a/ladxhd_game_source_code/ProjectZ.Android/Directory.Build.props
+++ b/ladxhd_game_source_code/ProjectZ.Android/Directory.Build.props
@@ -1,4 +1,6 @@
 <Project>
-
+  <PropertyGroup>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <CheckEolWorkloads>false</CheckEolWorkloads>
+  </PropertyGroup>
 </Project>
-

--- a/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
@@ -14,6 +14,8 @@
     <IsTrimmable>false</IsTrimmable>
     <EnableDefaultItems>true</EnableDefaultItems>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <CheckEolWorkloads>false</CheckEolWorkloads>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/ladxhd_game_source_code/ProjectZ.Core/Game1.cs
+++ b/ladxhd_game_source_code/ProjectZ.Core/Game1.cs
@@ -1,5 +1,5 @@
 ﻿﻿using System;
-﻿using System.IO;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using GBSPlayer;
@@ -101,6 +101,11 @@ namespace ProjectZ
         public static bool AutoLoadSave;
         public static int AutoLoadSlot;
 
+#if ANDROID
+        private static int _androidSurfaceWidthHint;
+        private static int _androidSurfaceHeightHint;
+#endif
+
         private static volatile bool _finishedLoading;
         private static volatile bool _isExiting;
 
@@ -131,10 +136,40 @@ namespace ProjectZ
 
         public static bool FinishedLoading => _finishedLoading;
 
+#if ANDROID
+        public static void SetAndroidSurfaceSizeHint(int width, int height)
+        {
+            if (width > 0 && height > 0)
+            {
+                _androidSurfaceWidthHint = width;
+                _androidSurfaceHeightHint = height;
+            }
+        }
+#endif
+
         public static Matrix GetMatrix
         {
             get
             {
+#if ANDROID
+                if (WindowWidth > 0 && WindowHeight > 0)
+                {
+                    var gd = Instance?.GraphicsDevice;
+                    if (gd != null)
+                    {
+                        var pp = gd.PresentationParameters;
+                        if (pp.BackBufferWidth > 0 && pp.BackBufferHeight > 0)
+                            return Matrix.CreateScale((float)pp.BackBufferWidth / WindowWidth, (float)pp.BackBufferHeight / WindowHeight, 1f);
+                    }
+
+                    if (Instance?.Window != null)
+                    {
+                        var cb = Instance.Window.ClientBounds;
+                        if (cb.Width > 0 && cb.Height > 0)
+                            return Matrix.CreateScale((float)cb.Width / WindowWidth, (float)cb.Height / WindowHeight, 1f);
+                    }
+                }
+#endif
                 return Matrix.CreateScale((float)Graphics.PreferredBackBufferWidth / WindowWidth, (float)Graphics.PreferredBackBufferHeight / WindowHeight, 1f);
             }
         }
@@ -170,6 +205,24 @@ namespace ProjectZ
             Graphics.GraphicsProfile = GraphicsProfile.HiDef;
             Graphics.PreferredBackBufferWidth = Values.MinWidth * 3;
             Graphics.PreferredBackBufferHeight = Values.MinHeight * 3;
+
+#if ANDROID
+            if (_androidSurfaceWidthHint > 0 && _androidSurfaceHeightHint > 0)
+            {
+                Graphics.PreferredBackBufferWidth = _androidSurfaceWidthHint;
+                Graphics.PreferredBackBufferHeight = _androidSurfaceHeightHint;
+            }
+            else
+            {
+                var displayMode = GraphicsAdapter.DefaultAdapter.CurrentDisplayMode;
+                if (displayMode.Width > 0 && displayMode.Height > 0)
+                {
+                    Graphics.PreferredBackBufferWidth = displayMode.Width;
+                    Graphics.PreferredBackBufferHeight = displayMode.Height;
+                }
+            }
+#endif
+
             Graphics.ApplyChanges();
 
             // Allow the user to resize the window.
@@ -472,10 +525,34 @@ namespace ProjectZ
                 Graphics.GraphicsDevice.SetRenderTarget(null);
                 GraphicsDevice.Clear(Color.Black);
 
+#if ANDROID
+                var pp = GraphicsDevice.PresentationParameters;
+                var targetWidth = pp.BackBufferWidth;
+                var targetHeight = pp.BackBufferHeight;
+
+                if (targetWidth <= 0 || targetHeight <= 0)
+                {
+                    var cb = Window.ClientBounds;
+                    targetWidth = cb.Width;
+                    targetHeight = cb.Height;
+                }
+
+                if (targetWidth <= 0 || targetHeight <= 0)
+                {
+                    var viewport = GraphicsDevice.Viewport;
+                    targetWidth = viewport.Width;
+                    targetHeight = viewport.Height;
+                }
+#else
                 var viewport = GraphicsDevice.Viewport;
+#endif
 
                 SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.Opaque, SamplerState.PointClamp, DepthStencilState.None, RasterizerState.CullNone);
+#if ANDROID
+                SpriteBatch.Draw(MainRenderTarget, new Rectangle(0, 0, targetWidth, targetHeight), Color.White);
+#else
                 SpriteBatch.Draw(MainRenderTarget, new Rectangle(0, 0, viewport.Width, viewport.Height), Color.White);
+#endif
                 SpriteBatch.End();
             }
 
@@ -691,17 +768,41 @@ namespace ProjectZ
 
         #if ANDROID
             // On Android, this can fire before GraphicsDevice exists (or during reset).
+            var cbWidth = Window?.ClientBounds.Width ?? 0;
+            var cbHeight = Window?.ClientBounds.Height ?? 0;
+
             if (GraphicsDevice != null)
             {
+                if (cbWidth > 0 && cbHeight > 0 &&
+                    (Graphics.PreferredBackBufferWidth != cbWidth || Graphics.PreferredBackBufferHeight != cbHeight))
+                {
+                    try
+                    {
+                        Graphics.PreferredBackBufferWidth = cbWidth;
+                        Graphics.PreferredBackBufferHeight = cbHeight;
+                        Graphics.ApplyChanges();
+                    }
+                    catch
+                    {
+                        // Keep running; we'll use the best available dimensions below.
+                    }
+                }
+
                 var pp = GraphicsDevice.PresentationParameters;
                 w = pp.BackBufferWidth;
                 h = pp.BackBufferHeight;
+
+                if (cbWidth > 0 && cbHeight > 0)
+                {
+                    w = cbWidth;
+                    h = cbHeight;
+                }
             }
             else
             {
                 // Fallback: at least keep sizes sane until GD exists
-                w = Window?.ClientBounds.Width ?? 0;
-                h = Window?.ClientBounds.Height ?? 0;
+                w = cbWidth;
+                h = cbHeight;
             }
         #else
             w = Window.ClientBounds.Width;

--- a/ladxhd_game_source_code/ProjectZ.Core/InGame/Overlay/HUDOverlay.cs
+++ b/ladxhd_game_source_code/ProjectZ.Core/InGame/Overlay/HUDOverlay.cs
@@ -112,12 +112,19 @@ namespace ProjectZ.InGame.Overlay
             _gameUiWindow.Width = (int)(Values.MinWidth * scale);
             _gameUiWindow.Height = (int)(Values.MinHeight * scale);
 
+#if ANDROID
+            _gameUiWindow.X = 0;
+            _gameUiWindow.Y = 0;
+            _gameUiWindow.Width = Game1.WindowWidth;
+            _gameUiWindow.Height = Game1.WindowHeight;
+#else
             var ar = MathHelper.Clamp(Game1.WindowWidth / (float)Game1.WindowHeight, 1, 2);
 
             _gameUiWindow.Width = MathHelper.Clamp((int)(Game1.WindowHeight * ar), 0, Game1.WindowWidth);
             _gameUiWindow.Height = MathHelper.Clamp((int)(Game1.WindowWidth / ar), 0, Game1.WindowHeight);
             _gameUiWindow.X = Game1.WindowWidth / 2 - _gameUiWindow.Width / 2;
             _gameUiWindow.Y = Game1.WindowHeight / 2 - _gameUiWindow.Height / 2;
+#endif
 
             // top left
             if (custom_rupee_show)

--- a/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>ProjectZ.Core</AssemblyName>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <CheckEolWorkloads>false</CheckEolWorkloads>
   </PropertyGroup>
 
   <!-- Exclude debug symbols when publishing -->

--- a/ladxhd_game_source_code/global.json
+++ b/ladxhd_game_source_code/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.418",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the black area that appeared around the game viewport on Android devices when running in fullscreen mode
- Corrects viewport sizing calculations to properly fill the screen on various Android display sizes and aspect ratios

## Test plan
- [x] Tested on Android device (Mangmi Air X) with fullscreen mode
- [x] Verified no black bars/areas appear around the game content
- [x] Confirmed desktop build is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)