### PR TITLE
Disable net8.0-android target framework on Linux.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
@@ -14,9 +14,13 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
-  <!-- Overrides the default target frameworks when building on Windows. -->
+  <!-- Override the default target frameworks per build platform. -->
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <!-- All build hosts support net8.0. -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <!-- Only include Android support on Windows and macOS (https://github.com/dotnet/sdk/issues/22411). -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-android</TargetFrameworks>
+    <!-- Only include Windows DirectX support on Windows. -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net8.0-windows</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Turns out dotnet doesn't support the Android workload on Linux, only on Windows and macOS: https://github.com/dotnet/sdk/issues/22411, thus breaking builds on Linux since the android workload can't be restored. The current patch only enables Android as a target when building from the supported Windows and macOS hosts.