### PR TITLE
Disable tiered compilation to reduce potential stutter.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
@@ -17,6 +17,7 @@
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CheckEolWorkloads>false</CheckEolWorkloads>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <!-- Release Builds: Most optimizations are disabled for compatibility packing multiple ABIs. -->

--- a/ladxhd_game_source_code/ProjectZ.Desktop/ProjectZ.Desktop.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Desktop/ProjectZ.Desktop.csproj
@@ -13,7 +13,7 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>false</ImplicitUsings>
     <PublishReadyToRun>false</PublishReadyToRun>
-    <TieredCompilation>true</TieredCompilation>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <!-- Windows DirectX: Forms is needed only to set the icon. -->

--- a/ladxhd_game_source_code/ProjectZ.Linux/ProjectZ.Linux.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Linux/ProjectZ.Linux.csproj
@@ -12,7 +12,7 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>false</ImplicitUsings>
     <PublishReadyToRun>false</PublishReadyToRun>
-    <TieredCompilation>true</TieredCompilation>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <!-- Include the editor from the Windows source. -->

--- a/ladxhd_game_source_code/ProjectZ.MacOS/ProjectZ.MacOS.csproj
+++ b/ladxhd_game_source_code/ProjectZ.MacOS/ProjectZ.MacOS.csproj
@@ -12,7 +12,7 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>false</ImplicitUsings>
     <PublishReadyToRun>false</PublishReadyToRun>
-    <TieredCompilation>true</TieredCompilation>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <!-- Include the editor from the Windows source. -->


### PR DESCRIPTION
MonoGame recommends disabling tiered compilation: while dynamic re-compilation can be worthy in server scenarios, it can result in stuttering during gameplay, which is always less desirable than slightly longer startup times, specially on lower-end devices.
See https://docs.monogame.net/articles/tutorials/building_2d_games/25_packaging_game/index.html?tabs=windows#tiered-compilation