### PR TITLE
Fix Unix finalizer scripts by ensuring line endings are respected.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts are always stored and checked out with Unix (LF) line endings.
+# This prevents Windows tooling from converting \n → \r\n, which breaks /bin/sh execution.
+*.sh text eol=lf

--- a/ladxhd_patcher_source_code/Program/Functions.cs
+++ b/ladxhd_patcher_source_code/Program/Functions.cs
@@ -284,10 +284,12 @@ namespace LADXHD_Patcher
             if (!HostEnvironment.IsWine)
                 return;
 
-            string scriptContent  = System.Text.Encoding.UTF8.GetString((byte[])resources[scriptResource]);
-            string scriptWinPath  = Path.Combine(Config.TempFolder, "finalize.sh");
-            File.WriteAllText(scriptWinPath, scriptContent,
-                              new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            // Write the script bytes verbatim so Unix line endings (LF) are preserved.
+            // File.WriteAllText on Windows would convert \n → \r\n via StreamWriter,
+            // which breaks /bin/sh execution of the extracted script.
+            byte[] scriptBytes   = (byte[])resources[scriptResource];
+            string scriptWinPath = Path.Combine(Config.TempFolder, "finalize.sh");
+            File.WriteAllBytes(scriptWinPath, scriptBytes);
 
             string scriptNativePath = ToUnixPath(scriptWinPath);
             string baseFolder       = ToUnixPath(Config.BaseFolder);


### PR DESCRIPTION
If at any point in the script handling line feeds are converted from Unix to DOS, the execution will fail on the Unix hosts. Let's avoid that by reading the scripts as bytes instead of transforming to text, and ensuring Git enforces Unix line endings for these files.