### PR TITLE
Editor: Fix broken mouse tracking in OpenGL ports.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Core/Base/InputHandler.cs
+++ b/ladxhd_game_source_code/ProjectZ.Core/Base/InputHandler.cs
@@ -357,15 +357,21 @@ namespace ProjectZ.Base
 
         public static Point MousePosition()
         {
-            // correct macOS (and potentially others?) notch offset when in fullscreen
-            int offY = Game1.FullScreen ? Game1.Graphics.PreferredBackBufferHeight - Game1.WindowHeight : 0;
+            // Correct for the OS safe-area offset in fullscreen (e.g. macOS notch).
+            // Use the adapter's actual display height rather than PreferredBackBufferHeight,
+            // which can be stale after ToggleFullscreen and would produce a wrong offset.
+            // On displays with no safe area (Windows, Linux, non-notch Macs) this is 0.
+            int offY = Game1.FullScreen ? Game1.Graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height - Game1.WindowHeight : 0;
             return new Point(_mouseState.X, _mouseState.Y - offY);
         }
 
         public static Point LastMousePosition()
         {
-            // correct macOS (and potentially others?) notch offset when in fullscreen
-            int offY = Game1.FullScreen ? Game1.Graphics.PreferredBackBufferHeight - Game1.WindowHeight : 0;
+            // Correct for the OS safe-area offset in fullscreen (e.g. macOS notch).
+            // Use the adapter's actual display height rather than PreferredBackBufferHeight,
+            // which can be stale after ToggleFullscreen and would produce a wrong offset.
+            // On displays with no safe area (Windows, Linux, non-notch Macs) this is 0.
+            int offY = Game1.FullScreen ? Game1.Graphics.GraphicsDevice.Adapter.CurrentDisplayMode.Height - Game1.WindowHeight : 0;
             return new Point(_lastMouseState.X, _lastMouseState.Y - offY);
         }
 


### PR DESCRIPTION
00fbd45 introduced logic to fix mouse tracking on MacBooks and other computers using a "notch": when in fullscreen, the operating system reserves a portion of the screen as a safe area to hide the notch, but the game was still calculating mouse coordinates accounting for that safe area, resulting in an offset between where the user was pointing, and our detected position.
The fix leveraged the difference between PreferredBackBufferHeight and actual WindowHeight to calculate that offset, but later a6c64a5 introduced changes to fullscreen and window size management that made that logic break, causing the mouse's offset to be way worse than before, making the editor pretty much unusable.
This fix takes the correct path we should have taken from the beginning: using the graphics adapter's reported window height instead of relying on the back buffer size (that can be manipulated from code), resulting in a stable calculation.