### PR TITLE
Patcher: fix broken Linux / macOS finalization after refactor.

### DIFF
--- a/ladxhd_patcher_source_code/Program/Functions.cs
+++ b/ladxhd_patcher_source_code/Program/Functions.cs
@@ -428,7 +428,7 @@ namespace LADXHD_Patcher
                     : "macos_arm64_files.zip";
 
                 // Extract the zip containing the MacOS files.
-                Utilities.ExtractResourcesZip(zipName, Config.TempFolder);
+                Utilities.ExtractResourcesZip(zipName, Config.BaseFolder);
             }
         }
 

--- a/ladxhd_patcher_source_code/Program/Functions.cs
+++ b/ladxhd_patcher_source_code/Program/Functions.cs
@@ -202,7 +202,7 @@ namespace LADXHD_Patcher
 
 /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-        POST PATCHING CODE : LINUX / MACOS INITIALIZATION SCRIPTS
+        POST PATCHING CODE : LINUX / MACOS FINALIZATION SCRIPTS
        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
@@ -290,11 +290,27 @@ namespace LADXHD_Patcher
             RunUnixFinalizeScript("finalize_macos.sh");
         }
 
-/*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+        private static void HostFinalizationFunctions()
+        {
+            bool isLinux = Config.SelectedPlatform == Platform.Linux_x86 || Config.SelectedPlatform == Platform.Linux_Arm64;
+            bool isMacOS = Config.SelectedPlatform == Platform.MacOS_x86 || Config.SelectedPlatform == Platform.MacOS_Arm64;
+            
+            // Finalization steps are platform-specific and should only run when patching on that platform.
+            if (isLinux && HostEnvironment.IsLinux)
+            {
+                RunLinuxFinalizeScript();
+            }
+            else if (isMacOS && HostEnvironment.IsMacOS)
+            {
+                RunMacOSFinalizeScript();
+            }
+        }
 
-        POST PATCHING CODE : ADDITIONAL FILE AND FOLDER HANDLING
-       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
+        /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+                POST PATCHING CODE : ADDITIONAL FILE AND FOLDER HANDLING
+
+        -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
         private static void CopyNewFiles()
         {
@@ -404,12 +420,6 @@ namespace LADXHD_Patcher
                 // Generate the APK file.
                 GenerateAPKFile();
             }
-            else if (Config.SelectedPlatform == Platform.Linux_x86 || Config.SelectedPlatform == Platform.Linux_Arm64)
-            {
-                // Finalization steps are platform-specific and should only run when patching on that platform.
-                if (HostEnvironment.IsLinux)
-                    RunLinuxFinalizeScript();
-            }
             else if (Config.SelectedPlatform == Platform.MacOS_x86 || Config.SelectedPlatform == Platform.MacOS_Arm64)
             {
                 // The files are different depending on MacOS CPU.
@@ -419,10 +429,6 @@ namespace LADXHD_Patcher
 
                 // Extract the zip containing the MacOS files.
                 Utilities.ExtractResourcesZip(zipName, Config.TempFolder);
-
-                // Finalization steps are platform-specific and should only run when patching on that platform.
-                if (HostEnvironment.IsMacOS)
-                    RunMacOSFinalizeScript();
             }
         }
 
@@ -856,6 +862,9 @@ namespace LADXHD_Patcher
             //Extract the launcher.
             ExtractLauncher();
 
+            // Linux / macOS finalization functions depend on both game and launcher being extracted.
+            HostFinalizationFunctions();
+
             // Report finished, remove temp path, enable dialog.
             ReportFinished();
             TryRemoveTempPath();
@@ -902,6 +911,9 @@ namespace LADXHD_Patcher
 
                 Console.WriteLine("Extracting launcher...");
                 ExtractLauncher();
+
+                Console.WriteLine("Performing platform-specific finalization...");
+                HostFinalizationFunctions();
 
                 Console.WriteLine("Cleaning up...");
                 XDelta3.Remove();


### PR DESCRIPTION
Linux and macOS finalization scripts must run after the launcher has been extracted since it's also treated by the scripts. During the last refactor launcher extraction came after the post-patching function where these scripts are called, making them miss the launcher files.

With the launcher performing so many steps on 4 different platforms, it might be interesting to consider setting up automated testing to identify these regressions that are bound to happen as code is changed. Another option would be to fully remove the per-platform extra steps and distribute / link them as separate helper scripts, that would hurt user experience though.