### PR TITLE
GitHub workflows to automatically build the Patcher.

### DIFF
--- a/.github/workflows/build-patcher.yml
+++ b/.github/workflows/build-patcher.yml
@@ -1,0 +1,92 @@
+name: Build Patcher
+
+on:
+  push:
+    paths:
+      - 'ladxhd_patcher_source_code/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      matrix:
+        include:
+          - profile: macOS-arm64
+            rid: osx-arm64
+            runner: macos-latest
+            ext: ''
+          - profile: macOS-x64
+            rid: osx-x64
+            runner: macos-latest
+            ext: ''
+          - profile: Linux-arm64
+            rid: linux-arm64
+            runner: ubuntu-latest
+            ext: ''
+          - profile: Linux-x64
+            rid: linux-x64
+            runner: ubuntu-latest
+            ext: ''
+          - profile: Windows
+            rid: win-x64
+            runner: windows-latest
+            ext: '.exe'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        working-directory: ladxhd_patcher_source_code
+        run: dotnet restore LADXHD_Patcher.csproj
+
+      - name: Get game version
+        id: get_version
+        shell: bash
+        run: |
+          VERSION=$(dotnet msbuild ladxhd_game_source_code/ProjectZ.Desktop/ProjectZ.Desktop.csproj -getProperty:Version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Publish
+        shell: bash
+        working-directory: ladxhd_patcher_source_code
+        run: |
+          dotnet publish LADXHD_Patcher.csproj \
+            -r ${{ matrix.rid }} \
+            -p:PublishProfile=${{ matrix.profile }}
+
+      - name: Rename patcher file
+        shell: bash
+        run: |
+          mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext }} \
+            ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD.Patcher.v${{ steps.get_version.outputs.version }}${{ matrix.ext }}
+
+      - name: Sign binary (macOS)
+        if: runner.os == 'macOS'
+        env:
+          APP_PATH: ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD.Patcher.v${{ steps.get_version.outputs.version }}
+        run: |
+          codesign --force --deep --sign - "$APP_PATH"
+          codesign --verify --verbose "$APP_PATH"
+
+      - name: Copy fix-permissions.sh (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          cp ladxhd_patcher_source_code/fix-macos-permissions.sh \
+            ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/fix-permissions.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: LADXHD.Patcher.v${{ steps.get_version.outputs.version }}_${{ matrix.profile }}-${{ github.run_id }}
+          path: |
+            ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/
+            !ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/nfd.lib
+            !ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/nfd.pdb

--- a/.github/workflows/gitlab-sync.yml
+++ b/.github/workflows/gitlab-sync.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   mirror:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     steps:

--- a/ladxhd_patcher_source_code/Imported/Mono.Options.cs
+++ b/ladxhd_patcher_source_code/Imported/Mono.Options.cs
@@ -1,3 +1,4 @@
+#pragma warning disable
 //
 // Options.cs
 //
@@ -2014,3 +2015,4 @@ namespace Mono.Options
 		}
 	}
 }
+#pragma warning restore


### PR DESCRIPTION
This PR adds 3 new GitHub workflows (one per platform) to trigger a Patcher build on every change inside `ladxhd_patcher_source_code` or when started manually from the Actions page.

This has a number of benefits, notably:
* Early detection of cross-platform compilation issues that might not have been identified locally.
* Builds to test changes always available and ready to share.
* Because each platform Patcher is built on its native platform, the builds are better optimized (e.g. macOS build doesn't include the Avalonia libraries anymore, it's a single file like Windows and Linux), and permission bits are properly set and respected (users don't need to `chmod +x` manually anymore on Linux/macOS).

The resulting artifacts can be used in releases removing the need to build everything manually on a single local machine anymore.

I have tested the [builds](https://github.com/aitorciki/Zelda-LA-DX-HD-Updated/actions) are fully functional on all the target systems.

It would be very easy to extend this to Launcher and Migrater too as a follow-up.