### PR TITLE
Add .bin extension to Linux patcher and migrater binaries

### DIFF
--- a/.github/workflows/build-migrater.yml
+++ b/.github/workflows/build-migrater.yml
@@ -16,22 +16,27 @@ jobs:
           - profile: macOS-arm64
             rid: osx-arm64
             runner: macos-latest
+            ext_src: '.app'
             ext: '.app'
           - profile: macOS-x64
             rid: osx-x64
             runner: macos-latest
+            ext_src: '.app'
             ext: '.app'
           - profile: Linux-arm64
             rid: linux-arm64
             runner: ubuntu-latest
-            ext: ''
+            ext_src: ''
+            ext: '.bin'
           - profile: Linux-x64
             rid: linux-x64
             runner: ubuntu-latest
-            ext: ''
+            ext_src: ''
+            ext: '.bin'
           - profile: Windows
             rid: win-x64
             runner: windows-latest
+            ext_src: '.exe'
             ext: '.exe'
 
     steps:
@@ -58,7 +63,7 @@ jobs:
       - name: Rename migrater file
         shell: bash
         run: |
-          mv ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/Migrater${{ matrix.ext }} \
+          mv ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/Migrater${{ matrix.ext_src }} \
             ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD_Migrater${{ matrix.ext }}
 
       - name: Sign binary (macOS)

--- a/.github/workflows/build-patcher.yml
+++ b/.github/workflows/build-patcher.yml
@@ -16,22 +16,27 @@ jobs:
           - profile: macOS-arm64
             rid: osx-arm64
             runner: macos-latest
+            ext_src: '.app'
             ext: '.app'
           - profile: macOS-x64
             rid: osx-x64
             runner: macos-latest
+            ext_src: '.app'
             ext: '.app'
           - profile: Linux-arm64
             rid: linux-arm64
             runner: ubuntu-latest
-            ext: ''
+            ext_src: ''
+            ext: '.bin'
           - profile: Linux-x64
             rid: linux-x64
             runner: ubuntu-latest
-            ext: ''
+            ext_src: ''
+            ext: '.bin'
           - profile: Windows
             rid: win-x64
             runner: windows-latest
+            ext_src: '.exe'
             ext: '.exe'
 
     steps:
@@ -65,7 +70,7 @@ jobs:
       - name: Rename patcher file
         shell: bash
         run: |
-          mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext }} \
+          mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext_src }} \
             ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD.Patcher.v${{ steps.get_version.outputs.version }}${{ matrix.ext }}
 
       - name: Sign binary (macOS)

--- a/ladxhd_migrate_source_code/publish.bat
+++ b/ladxhd_migrate_source_code/publish.bat
@@ -49,12 +49,12 @@ if exist "%Root%\~Publish\Windows\Migrater.exe" (
     ren "%Root%\~Publish\Windows\Migrater.exe" "LADXHD_Migrater.exe"
 )
 if exist "%Root%\~Publish\Linux-x64\Migrater" (
-    echo Renaming: "%Root%\~Publish\Linux-x64\Migrater" to "LADXHD_Migrater"
-    ren "%Root%\~Publish\Linux-x64\Migrater" "LADXHD_Migrater"
+    echo Renaming: "%Root%\~Publish\Linux-x64\Migrater" to "LADXHD_Migrater.bin"
+    ren "%Root%\~Publish\Linux-x64\Migrater" "LADXHD_Migrater.bin"
 )
 if exist "%Root%\~Publish\Linux-arm64\Migrater" (
-    echo Renaming: "%Root%\~Publish\Linux-arm64\Migrater" to "LADXHD_Migrater"
-    ren "%Root%\~Publish\Linux-arm64\Migrater" "LADXHD_Migrater"
+    echo Renaming: "%Root%\~Publish\Linux-arm64\Migrater" to "LADXHD_Migrater.bin"
+    ren "%Root%\~Publish\Linux-arm64\Migrater" "LADXHD_Migrater.bin"
 )
 if exist "%Root%\~Publish\macOS-x64\Migrater.app" (
     echo Renaming: "%Root%\~Publish\macOS-x64\Migrater.app" to "LADXHD_Migrater.app"

--- a/ladxhd_patcher_source_code/publish.bat
+++ b/ladxhd_patcher_source_code/publish.bat
@@ -55,12 +55,12 @@ if exist "%Root%\~Publish\Windows\Patcher.exe" (
     ren "%Root%\~Publish\Windows\Patcher.exe" "LADXHD.Patcher.v%GameVersion%.exe"
 )
 if exist "%Root%\~Publish\Linux-x64\Patcher" (
-    echo Renaming: "%Root%\~Publish\Linux-x64\Patcher" to "LADXHD.Patcher.v%GameVersion%"
-    ren "%Root%\~Publish\Linux-x64\Patcher" "LADXHD.Patcher.v%GameVersion%"
+    echo Renaming: "%Root%\~Publish\Linux-x64\Patcher" to "LADXHD.Patcher.v%GameVersion%.bin"
+    ren "%Root%\~Publish\Linux-x64\Patcher" "LADXHD.Patcher.v%GameVersion%.bin"
 )
 if exist "%Root%\~Publish\Linux-arm64\Patcher" (
-    echo Renaming: "%Root%\~Publish\Linux-arm64\Patcher" to "LADXHD.Patcher.v%GameVersion%"
-    ren "%Root%\~Publish\Linux-arm64\Patcher" "LADXHD.Patcher.v%GameVersion%"
+    echo Renaming: "%Root%\~Publish\Linux-arm64\Patcher" to "LADXHD.Patcher.v%GameVersion%.bin"
+    ren "%Root%\~Publish\Linux-arm64\Patcher" "LADXHD.Patcher.v%GameVersion%.bin"
 )
 if exist "%Root%\~Publish\macOS-x64\Patcher.app" (
     echo Renaming: "%Root%\~Publish\macOS-x64\Patcher.app" to "LADXHD.Patcher.v%GameVersion%.app"


### PR DESCRIPTION
As encountered before with macOS, the name of the binaries confuses some file browsers on Linux, that try to open the binary as a text file or similar. Using the .bin extension seems to provide a more consistent behaviour.

This might not be enough though, as .bin is not a standard extension or anything similar. If some setups keep refusing to launch the patcher we might need to package it as an AppImage which is the standard, blessed mechanism to distribute single-file apps in the system.

Hopefully fixes #845 in most cases.