### PR TITLE
Android: re-add version info to manifest.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Android/AndroidManifest.xml
+++ b/ladxhd_game_source_code/ProjectZ.Android/AndroidManifest.xml
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.zelda.ladxhd"
+          android:versionCode="182"
+          android:versionName="1.8.2"
           android:screenOrientation="landscape"
           android:configChanges="orientation|keyboardHidden|screenSize">
 


### PR DESCRIPTION
AndroidManifest.xml is not part of the .NET building pipeline, and as such won't read from the shared project version information. Without version fields the APK defaults to version 1, which won't allow any installed version to update since 1 is always an older version that whatever is already installed.

Fixes #851 