### PR TITLE
Android: set version through .NET Android SDK merging.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Android/AndroidManifest.xml
+++ b/ladxhd_game_source_code/ProjectZ.Android/AndroidManifest.xml
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.zelda.ladxhd"
-          android:versionCode="182"
-          android:versionName="1.8.2"
           android:screenOrientation="landscape"
           android:configChanges="orientation|keyboardHidden|screenSize">
 

--- a/ladxhd_game_source_code/ProjectZ.Android/Directory.Build.props
+++ b/ladxhd_game_source_code/ProjectZ.Android/Directory.Build.props
@@ -1,4 +1,7 @@
 <Project>
+  <!-- Chain up to inherit shared properties from parent Directory.Build.props files. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
   <PropertyGroup>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CheckEolWorkloads>false</CheckEolWorkloads>

--- a/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Android/ProjectZ.Android.csproj
@@ -43,7 +43,7 @@
 
   <!-- Include the Android files that are needed. -->
   <ItemGroup>
-    <None Include="AndroidManifest.xml" />
+    <AndroidManifest Include="AndroidManifest.xml" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Resources\AboutResources.txt" />
     <AndroidResource Include="Resources\drawable\icon_foreground.xml" />


### PR DESCRIPTION
In a nutshell, fix inferring the Android manifest correct versions from the centralized .NET build config.