### PR TITLE
Migrater: cross-platform builds + all functions supported in headless mode.

### DIFF
--- a/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
+++ b/ladxhd_game_source_code/ProjectZ.Core/ProjectZ.Core.csproj
@@ -11,7 +11,7 @@
     <!-- Add Android build support on Windows/macOS. -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or $([MSBuild]::IsOSPlatform('OSX'))">$(TargetFrameworks);net8.0-android</TargetFrameworks>
     <!-- Add DirectX build support on Windows. -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net8.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows')) or '$(EnableWindowsTargeting)' == 'true'">$(TargetFrameworks);net8.0-windows</TargetFrameworks>
 
     <!-- Desktop-specific RIDs (exclude from Android to fix build errors). -->
     <RuntimeIdentifiers Condition="'$(TargetFramework)' != 'net8.0-android'">win-x64;linux-x64;linux-arm64;osx-arm64;osx-x64</RuntimeIdentifiers>

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 using Avalonia;
 using Mono.Options;
 
@@ -19,18 +20,29 @@ namespace LADXHD_Migrater
         private const int ATTACH_PARENT_PROCESS = -1;
 
         [STAThread]
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             bool showHelp = false;
             bool migrateAssets = false;
+            bool createPatches = false;
+            bool cleanBuild = false;
+            string? buildPlatform = null;
+            string? graphicsStr = null;
 
             var opts = new OptionSet {
                 { "migrate-assets|m",  "Run asset migration in headless mode.",     _ => migrateAssets = true },
+                { "create-patches|p",  "Create vcdiff patches from modified files.", _ => createPatches = true },
+                { "clean-build|c",     "Remove all bin/obj/Publish folders.",        _ => cleanBuild = true },
+                { "build|b:",          "Build for platform [windows|android|linux-x86|linux-arm64|macos-x86|macos-arm64]. Default: windows.", v => buildPlatform = v },
+                { "graphics=",         "Target graphics API: directx, opengl. Default: directx (windows), opengl (others).", v => graphicsStr = v },
                 { "headless",          "Deprecated. Use --migrate-assets instead.", _ => showHelp = true },
                 { "h|?|help",          "Show this help message.",                   _ => showHelp = true },
             };
 
             opts.Parse(args);
+
+            if (buildPlatform != null && string.IsNullOrWhiteSpace(buildPlatform))
+                buildPlatform = "windows";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 AttachConsole(ATTACH_PARENT_PROCESS);
@@ -44,17 +56,62 @@ namespace LADXHD_Migrater
                 Console.WriteLine("Options:");
                 opts.WriteOptionDescriptions(Console.Out);
                 Console.WriteLine();
-                Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Migration failed");
+                Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Operation failed, 3=Invalid arguments");
                 Console.WriteLine();
                 return 0;
             }
 
-            if (migrateAssets)
+            if (migrateAssets || createPatches || cleanBuild || buildPlatform != null)
             {
+                Functions.HeadlessMode = true;
                 Config.Initialize();
                 BuildAvaloniaApp().SetupWithoutStarting();
-                Functions.HeadlessMode = true;
 
+                if (buildPlatform != null)
+                {
+                    try
+                    {
+                        Config.Platform platform = buildPlatform.ToLowerInvariant() switch
+                        {
+                            "windows"     => Config.Platform.Windows,
+                            "android"     => Config.Platform.Android,
+                            "linux-x86"   => Config.Platform.Linux_x64,
+                            "linux-arm64" => Config.Platform.Linux_Arm64,
+                            "macos-x86"   => Config.Platform.MacOS_x64,
+                            "macos-arm64" => Config.Platform.MacOS_Arm64,
+                            _ => throw new ArgumentException($"Invalid --build value '{buildPlatform}'. Valid values: windows, android, linux-x86, linux-arm64, macos-x86, macos-arm64")
+                        };
+
+                        Config.GraphicsAPI graphics;
+                        if (graphicsStr != null)
+                        {
+                            graphics = graphicsStr.ToLowerInvariant() switch
+                            {
+                                "directx" => Config.GraphicsAPI.DirectX,
+                                "opengl"  => Config.GraphicsAPI.OpenGL,
+                                _ => throw new ArgumentException($"Invalid --graphics value '{graphicsStr}'. Valid values: directx, opengl")
+                            };
+                            if (graphics == Config.GraphicsAPI.DirectX && platform != Config.Platform.Windows)
+                                throw new ArgumentException("--graphics directx is only supported on Windows. Use --graphics opengl for other platforms.");
+                        }
+                        else
+                        {
+                            graphics = (platform == Config.Platform.Windows) ? Config.GraphicsAPI.DirectX : Config.GraphicsAPI.OpenGL;
+                        }
+
+                        Config.SelectedPlatform = platform;
+                        Config.SelectedGraphics = graphics;
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        Console.Error.WriteLine("ERROR: " + ex.Message);
+                        return 3;
+                    }
+                }
+            }
+
+            if (migrateAssets)
+            {
                 if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
                 {
                     Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
@@ -72,6 +129,65 @@ namespace LADXHD_Migrater
                 }
 
                 Console.WriteLine("Migration complete.");
+                return 0;
+            }
+
+            if (createPatches)
+            {
+                if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+                {
+                    Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
+                    return 1;
+                }
+                if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
+                {
+                    Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
+                    return 1;
+                }
+
+                try
+                {
+                    Functions.CreatePatches();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine("ERROR: " + ex.Message);
+                    return 2;
+                }
+
+                Console.WriteLine("Patches created.");
+                return 0;
+            }
+
+            if (cleanBuild)
+            {
+                try
+                {
+                    Functions.CleanBuildFiles();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine("ERROR: " + ex.Message);
+                    return 2;
+                }
+
+                Console.WriteLine("Build files cleaned.");
+                return 0;
+            }
+
+            if (buildPlatform != null)
+            {
+                try
+                {
+                    await Functions.CreateBuild();
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine("ERROR: " + ex.Message);
+                    return 2;
+                }
+
+                Console.WriteLine("Build complete.");
                 return 0;
             }
 

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -195,7 +195,12 @@ namespace LADXHD_Migrater
                 {
                     try
                     {
-                        await Functions.CreateBuild();
+                        bool success = await Functions.CreateBuild();
+                        if (!success)
+                        {
+                            Console.Error.WriteLine("ERROR: Build failed.");
+                            ExitHeadless(2);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Threading.Tasks;
 using Avalonia;
 using Mono.Options;
 
@@ -9,25 +9,8 @@ namespace LADXHD_Migrater
 {
     internal class Program
     {
-        [SupportedOSPlatform("windows")]
-        [DllImport("kernel32.dll")]
-        private static extern bool AttachConsole(int dwProcessId);
-
-        [SupportedOSPlatform("windows")]
-        [DllImport("kernel32.dll")]
-        private static extern bool FreeConsole();
-
-        private const int ATTACH_PARENT_PROCESS = -1;
-
-        private static void ExitHeadless(int exitCode)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                FreeConsole();
-            Environment.Exit(exitCode);
-        }
-
         [STAThread]
-        public static async Task<int> Main(string[] args)
+        public static int Main(string[] args)
         {
             bool showHelp = false;
             bool migrateAssets = false;
@@ -38,28 +21,25 @@ namespace LADXHD_Migrater
             string? graphicsStr = null;
 
             var opts = new OptionSet {
-                { "migrate-assets|m",  "Run asset migration in headless mode.",      _ => migrateAssets = true },
+                { "migrate-assets|m",  "Run asset migration in headless mode.",     _ => migrateAssets = true },
                 { "create-patches|p",  "Create vcdiff patches from modified files.", _ => createPatches = true },
                 { "clean-build|c",     "Remove all bin/obj/Publish folders.",        _ => cleanBuild = true },
                 { "build|b:",          "Build for platform [windows|android|linux-x86|linux-arm64|macos-x86|macos-arm64]. Default: current platform.", v => { buildRequested = true; buildPlatform = v; } },
                 { "graphics=",         "Target graphics API: directx, opengl. Default: directx (windows), opengl (others).", v => graphicsStr = v },
-                { "headless",          "Deprecated. Use --migrate-assets instead.",  _ => showHelp = true },
-                { "h|?|help",          "Show this help message.",                    _ => showHelp = true },
+                { "headless",          "Deprecated. Use --migrate-assets instead.", _ => showHelp = true },
+                { "h|?|help",          "Show this help message.",                   _ => showHelp = true },
             };
 
             opts.Parse(args);
 
             if (showHelp)
-            {
-                ShowHelp(opts);
-                return 0;
-            }
+                return ShowHelp(opts);
 
             if (buildRequested && buildPlatform == null)
                 SetNativePlatform();
 
             if (migrateAssets || createPatches || cleanBuild || buildRequested)
-                await RunHeadlessAsync(migrateAssets, createPatches, cleanBuild, buildRequested, buildPlatform, graphicsStr);
+                return RunHeadless(migrateAssets, createPatches, cleanBuild, buildRequested, buildPlatform, graphicsStr);
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
             return 0;
@@ -71,11 +51,9 @@ namespace LADXHD_Migrater
                 .WithInterFont()
                 .LogToTrace();
 
-        private static void ShowHelp(Mono.Options.OptionSet opts)
+        private static int ShowHelp(Mono.Options.OptionSet opts)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                AttachConsole(ATTACH_PARENT_PROCESS);
-
+            TryReconnectConsole();
             Console.WriteLine();
             Console.WriteLine("LADXHD Migrater");
             Console.WriteLine("Usage: Migrater [options]");
@@ -85,8 +63,7 @@ namespace LADXHD_Migrater
             Console.WriteLine();
             Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Operation failed, 3=Invalid arguments");
             Console.WriteLine();
-
-            ExitHeadless(0);
+            return 0;
         }
 
         private static void SetNativePlatform()
@@ -95,6 +72,34 @@ namespace LADXHD_Migrater
             Config.SelectedGraphics = (Config.SelectedPlatform == Config.Platform.Windows)
                 ? Config.GraphicsAPI.DirectX
                 : Config.GraphicsAPI.OpenGL;
+        }
+
+        private static int RunHeadless(bool migrateAssets, bool createPatches, bool cleanBuild, bool buildRequested, string? buildPlatform, string? graphicsStr)
+        {
+            TryReconnectConsole();
+            Functions.HeadlessMode = true;
+            Config.Initialize();
+            BuildAvaloniaApp().SetupWithoutStarting();
+
+            if (buildRequested && buildPlatform != null)
+            {
+                try
+                {
+                    ParsePlatform(buildPlatform, graphicsStr);
+                }
+                catch (ArgumentException ex)
+                {
+                    Console.Error.WriteLine("ERROR: " + ex.Message);
+                    return 3;
+                }
+            }
+
+            if (migrateAssets)      return RunMigrate();
+            if (createPatches)     return RunCreatePatches();
+            if (cleanBuild)        return RunCleanBuild();
+            if (buildRequested)    return RunBuild();
+
+            return 0;
         }
 
         private static void ParsePlatform(string buildPlatform, string? graphicsStr)
@@ -131,40 +136,12 @@ namespace LADXHD_Migrater
             Config.SelectedGraphics = graphics;
         }
 
-        private static async Task RunHeadlessAsync(bool migrateAssets, bool createPatches, bool cleanBuild, bool buildRequested, string? buildPlatform, string? graphicsStr)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                AttachConsole(ATTACH_PARENT_PROCESS);
-
-            Functions.HeadlessMode = true;
-            Config.Initialize();
-            BuildAvaloniaApp().SetupWithoutStarting();
-
-            if (buildRequested && buildPlatform != null)
-            {
-                try
-                {
-                    ParsePlatform(buildPlatform, graphicsStr);
-                }
-                catch (ArgumentException ex)
-                {
-                    Console.Error.WriteLine("ERROR: " + ex.Message);
-                    ExitHeadless(3);
-                }
-            }
-
-            if (migrateAssets)      RunMigrate();
-            if (createPatches)      RunCreatePatches();
-            if (cleanBuild)         RunCleanBuild();
-            if (buildRequested)     await RunBuildAsync();
-        }
-
-        private static void RunMigrate()
+        private static int RunMigrate()
         {
             if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
             {
                 Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                ExitHeadless(1);
+                return 1;
             }
 
             try
@@ -174,24 +151,24 @@ namespace LADXHD_Migrater
             catch (Exception ex)
             {
                 Console.Error.WriteLine("ERROR: " + ex.Message);
-                ExitHeadless(2);
+                return 2;
             }
 
             Console.WriteLine("Migration complete.");
-            ExitHeadless(0);
+            return 0;
         }
 
-        private static void RunCreatePatches()
+        private static int RunCreatePatches()
         {
             if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
             {
                 Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                ExitHeadless(1);
+                return 1;
             }
             if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
             {
                 Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
-                ExitHeadless(1);
+                return 1;
             }
 
             try
@@ -201,14 +178,14 @@ namespace LADXHD_Migrater
             catch (Exception ex)
             {
                 Console.Error.WriteLine("ERROR: " + ex.Message);
-                ExitHeadless(2);
+                return 2;
             }
 
             Console.WriteLine("Patches created.");
-            ExitHeadless(0);
+            return 0;
         }
 
-        private static void RunCleanBuild()
+        private static int RunCleanBuild()
         {
             try
             {
@@ -217,32 +194,73 @@ namespace LADXHD_Migrater
             catch (Exception ex)
             {
                 Console.Error.WriteLine("ERROR: " + ex.Message);
-                ExitHeadless(2);
+                return 2;
             }
 
             Console.WriteLine("Build files cleaned.");
-            ExitHeadless(0);
+            return 0;
         }
 
-        private static async Task RunBuildAsync()
+        private static int RunBuild()
         {
             try
             {
-                bool success = await Functions.CreateBuild();
+                bool success = Functions.CreateBuild().GetAwaiter().GetResult();
                 if (!success)
                 {
                     Console.Error.WriteLine("ERROR: Build failed.");
-                    ExitHeadless(2);
+                    return 2;
                 }
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine("ERROR: " + ex.Message);
-                ExitHeadless(2);
+                return 2;
             }
 
             Console.WriteLine("Build complete.");
-            ExitHeadless(0);
+            return 0;
+        }
+
+        // ---- Windows console re-attachment (headless mode) ----
+
+        [SupportedOSPlatform("windows")]
+        [DllImport("kernel32.dll")]
+        private static extern bool AttachConsole(int dwProcessId);
+
+        [SupportedOSPlatform("windows")]
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+        [SupportedOSPlatform("windows")]
+        [DllImport("kernel32.dll")]
+        private static extern bool SetStdHandle(int nStdHandle, IntPtr hHandle);
+
+        [SupportedOSPlatform("windows")]
+        private static void TryReconnectConsole()
+        {
+            const int  ATTACH_PARENT_PROCESS = -1;
+            const int  STD_OUTPUT_HANDLE     = -11;
+            const int  STD_ERROR_HANDLE      = -12;
+            const uint GENERIC_READ          = 0x80000000;
+            const uint GENERIC_WRITE         = 0x40000000;
+            const uint OPEN_EXISTING         = 3;
+            const uint FILE_SHARE_WRITE      = 2;
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+            if (!AttachConsole(ATTACH_PARENT_PROCESS)) return;
+
+            IntPtr hOut = CreateFile("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE, IntPtr.Zero, OPEN_EXISTING, 0, IntPtr.Zero);
+            if (hOut != new IntPtr(-1))
+            {
+                SetStdHandle(STD_OUTPUT_HANDLE, hOut);
+                SetStdHandle(STD_ERROR_HANDLE, hOut);
+            }
+
+            var stream = new FileStream(new Microsoft.Win32.SafeHandles.SafeFileHandle(hOut, false), FileAccess.Write);
+            var writer = new StreamWriter(stream) { AutoFlush = true };
+            Console.SetOut(writer);
+            Console.SetError(writer);
         }
     }
 }

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -19,6 +19,13 @@ namespace LADXHD_Migrater
 
         private const int ATTACH_PARENT_PROCESS = -1;
 
+        private static void ExitHeadless(int exitCode)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                FreeConsole();
+            Environment.Exit(exitCode);
+        }
+
         [STAThread]
         public static async Task<int> Main(string[] args)
         {
@@ -44,11 +51,11 @@ namespace LADXHD_Migrater
             if (buildPlatform != null && string.IsNullOrWhiteSpace(buildPlatform))
                 buildPlatform = "windows";
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                AttachConsole(ATTACH_PARENT_PROCESS);
-
             if (showHelp)
             {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    AttachConsole(ATTACH_PARENT_PROCESS);
+
                 Console.WriteLine();
                 Console.WriteLine("LADXHD Migrater");
                 Console.WriteLine("Usage: Migrater [options]");
@@ -58,11 +65,15 @@ namespace LADXHD_Migrater
                 Console.WriteLine();
                 Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Operation failed, 3=Invalid arguments");
                 Console.WriteLine();
-                return 0;
+
+                ExitHeadless(0);
             }
 
             if (migrateAssets || createPatches || cleanBuild || buildPlatform != null)
             {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    AttachConsole(ATTACH_PARENT_PROCESS);
+
                 Functions.HeadlessMode = true;
                 Config.Initialize();
                 BuildAvaloniaApp().SetupWithoutStarting();
@@ -105,90 +116,90 @@ namespace LADXHD_Migrater
                     catch (ArgumentException ex)
                     {
                         Console.Error.WriteLine("ERROR: " + ex.Message);
-                        return 3;
+                        ExitHeadless(3);
                     }
                 }
-            }
 
-            if (migrateAssets)
-            {
-                if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+                if (migrateAssets)
                 {
-                    Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                    return 1;
-                }
+                    if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+                    {
+                        Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
+                        ExitHeadless(1);
+                    }
 
-                try
-                {
-                    Functions.MigrateFiles();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine("ERROR: " + ex.Message);
-                    return 2;
-                }
+                    try
+                    {
+                        Functions.MigrateFiles();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("ERROR: " + ex.Message);
+                        ExitHeadless(2);
+                    }
 
-                Console.WriteLine("Migration complete.");
-                return 0;
-            }
-
-            if (createPatches)
-            {
-                if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
-                {
-                    Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                    return 1;
-                }
-                if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
-                {
-                    Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
-                    return 1;
+                    Console.WriteLine("Migration complete.");
+                    ExitHeadless(0);
                 }
 
-                try
+                if (createPatches)
                 {
-                    Functions.CreatePatches();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine("ERROR: " + ex.Message);
-                    return 2;
+                    if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+                    {
+                        Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
+                        ExitHeadless(1);
+                    }
+                    if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
+                    {
+                        Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
+                        ExitHeadless(1);
+                    }
+
+                    try
+                    {
+                        Functions.CreatePatches();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("ERROR: " + ex.Message);
+                        ExitHeadless(2);
+                    }
+
+                    Console.WriteLine("Patches created.");
+                    ExitHeadless(0);
                 }
 
-                Console.WriteLine("Patches created.");
-                return 0;
-            }
+                if (cleanBuild)
+                {
+                    try
+                    {
+                        Functions.CleanBuildFiles();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("ERROR: " + ex.Message);
+                        ExitHeadless(2);
+                    }
 
-            if (cleanBuild)
-            {
-                try
-                {
-                    Functions.CleanBuildFiles();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine("ERROR: " + ex.Message);
-                    return 2;
-                }
-
-                Console.WriteLine("Build files cleaned.");
-                return 0;
-            }
-
-            if (buildPlatform != null)
-            {
-                try
-                {
-                    await Functions.CreateBuild();
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine("ERROR: " + ex.Message);
-                    return 2;
+                    Console.WriteLine("Build files cleaned.");
+                    ExitHeadless(0);
                 }
 
-                Console.WriteLine("Build complete.");
-                return 0;
+                if (buildPlatform != null)
+                {
+                    try
+                    {
+                        await Functions.CreateBuild();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("ERROR: " + ex.Message);
+                        ExitHeadless(2);
+                    }
+
+                    Console.WriteLine("Build complete.");
+                    ExitHeadless(0);
+                }
             }
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -33,23 +33,29 @@ namespace LADXHD_Migrater
             bool migrateAssets = false;
             bool createPatches = false;
             bool cleanBuild = false;
+            bool buildRequested = false;
             string? buildPlatform = null;
             string? graphicsStr = null;
 
             var opts = new OptionSet {
-                { "migrate-assets|m",  "Run asset migration in headless mode.",     _ => migrateAssets = true },
+                { "migrate-assets|m",  "Run asset migration in headless mode.",      _ => migrateAssets = true },
                 { "create-patches|p",  "Create vcdiff patches from modified files.", _ => createPatches = true },
                 { "clean-build|c",     "Remove all bin/obj/Publish folders.",        _ => cleanBuild = true },
-                { "build|b:",          "Build for platform [windows|android|linux-x86|linux-arm64|macos-x86|macos-arm64]. Default: windows.", v => buildPlatform = v },
+                { "build|b:",          "Build for platform [windows|android|linux-x86|linux-arm64|macos-x86|macos-arm64]. Default: current platform.", v => { buildRequested = true; buildPlatform = v; } },
                 { "graphics=",         "Target graphics API: directx, opengl. Default: directx (windows), opengl (others).", v => graphicsStr = v },
-                { "headless",          "Deprecated. Use --migrate-assets instead.", _ => showHelp = true },
-                { "h|?|help",          "Show this help message.",                   _ => showHelp = true },
+                { "headless",          "Deprecated. Use --migrate-assets instead.",  _ => showHelp = true },
+                { "h|?|help",          "Show this help message.",                    _ => showHelp = true },
             };
 
             opts.Parse(args);
 
-            if (buildPlatform != null && string.IsNullOrWhiteSpace(buildPlatform))
-                buildPlatform = "windows";
+            if (buildRequested && buildPlatform == null)
+            {
+                Config.SelectedPlatform = Config.GetNativePlatform();
+                Config.SelectedGraphics = (Config.SelectedPlatform == Config.Platform.Windows)
+                    ? Config.GraphicsAPI.DirectX
+                    : Config.GraphicsAPI.OpenGL;
+            }
 
             if (showHelp)
             {
@@ -69,7 +75,7 @@ namespace LADXHD_Migrater
                 ExitHeadless(0);
             }
 
-            if (migrateAssets || createPatches || cleanBuild || buildPlatform != null)
+            if (migrateAssets || createPatches || cleanBuild || buildRequested)
             {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     AttachConsole(ATTACH_PARENT_PROCESS);
@@ -78,7 +84,7 @@ namespace LADXHD_Migrater
                 Config.Initialize();
                 BuildAvaloniaApp().SetupWithoutStarting();
 
-                if (buildPlatform != null)
+                if (buildRequested && buildPlatform != null)
                 {
                     try
                     {
@@ -185,7 +191,7 @@ namespace LADXHD_Migrater
                     ExitHeadless(0);
                 }
 
-                if (buildPlatform != null)
+                if (buildRequested)
                 {
                     try
                     {

--- a/ladxhd_migrate_source_code/Program.cs
+++ b/ladxhd_migrate_source_code/Program.cs
@@ -49,169 +49,17 @@ namespace LADXHD_Migrater
 
             opts.Parse(args);
 
-            if (buildRequested && buildPlatform == null)
-            {
-                Config.SelectedPlatform = Config.GetNativePlatform();
-                Config.SelectedGraphics = (Config.SelectedPlatform == Config.Platform.Windows)
-                    ? Config.GraphicsAPI.DirectX
-                    : Config.GraphicsAPI.OpenGL;
-            }
-
             if (showHelp)
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    AttachConsole(ATTACH_PARENT_PROCESS);
-
-                Console.WriteLine();
-                Console.WriteLine("LADXHD Migrater");
-                Console.WriteLine("Usage: Migrater [options]");
-                Console.WriteLine();
-                Console.WriteLine("Options:");
-                opts.WriteOptionDescriptions(Console.Out);
-                Console.WriteLine();
-                Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Operation failed, 3=Invalid arguments");
-                Console.WriteLine();
-
-                ExitHeadless(0);
+                ShowHelp(opts);
+                return 0;
             }
+
+            if (buildRequested && buildPlatform == null)
+                SetNativePlatform();
 
             if (migrateAssets || createPatches || cleanBuild || buildRequested)
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    AttachConsole(ATTACH_PARENT_PROCESS);
-
-                Functions.HeadlessMode = true;
-                Config.Initialize();
-                BuildAvaloniaApp().SetupWithoutStarting();
-
-                if (buildRequested && buildPlatform != null)
-                {
-                    try
-                    {
-                        Config.Platform platform = buildPlatform.ToLowerInvariant() switch
-                        {
-                            "windows"     => Config.Platform.Windows,
-                            "android"     => Config.Platform.Android,
-                            "linux-x86"   => Config.Platform.Linux_x64,
-                            "linux-arm64" => Config.Platform.Linux_Arm64,
-                            "macos-x86"   => Config.Platform.MacOS_x64,
-                            "macos-arm64" => Config.Platform.MacOS_Arm64,
-                            _ => throw new ArgumentException($"Invalid --build value '{buildPlatform}'. Valid values: windows, android, linux-x86, linux-arm64, macos-x86, macos-arm64")
-                        };
-
-                        Config.GraphicsAPI graphics;
-                        if (graphicsStr != null)
-                        {
-                            graphics = graphicsStr.ToLowerInvariant() switch
-                            {
-                                "directx" => Config.GraphicsAPI.DirectX,
-                                "opengl"  => Config.GraphicsAPI.OpenGL,
-                                _ => throw new ArgumentException($"Invalid --graphics value '{graphicsStr}'. Valid values: directx, opengl")
-                            };
-                            if (graphics == Config.GraphicsAPI.DirectX && platform != Config.Platform.Windows)
-                                throw new ArgumentException("--graphics directx is only supported on Windows. Use --graphics opengl for other platforms.");
-                        }
-                        else
-                        {
-                            graphics = (platform == Config.Platform.Windows) ? Config.GraphicsAPI.DirectX : Config.GraphicsAPI.OpenGL;
-                        }
-
-                        Config.SelectedPlatform = platform;
-                        Config.SelectedGraphics = graphics;
-                    }
-                    catch (ArgumentException ex)
-                    {
-                        Console.Error.WriteLine("ERROR: " + ex.Message);
-                        ExitHeadless(3);
-                    }
-                }
-
-                if (migrateAssets)
-                {
-                    if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
-                    {
-                        Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                        ExitHeadless(1);
-                    }
-
-                    try
-                    {
-                        Functions.MigrateFiles();
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine("ERROR: " + ex.Message);
-                        ExitHeadless(2);
-                    }
-
-                    Console.WriteLine("Migration complete.");
-                    ExitHeadless(0);
-                }
-
-                if (createPatches)
-                {
-                    if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
-                    {
-                        Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
-                        ExitHeadless(1);
-                    }
-                    if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
-                    {
-                        Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
-                        ExitHeadless(1);
-                    }
-
-                    try
-                    {
-                        Functions.CreatePatches();
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine("ERROR: " + ex.Message);
-                        ExitHeadless(2);
-                    }
-
-                    Console.WriteLine("Patches created.");
-                    ExitHeadless(0);
-                }
-
-                if (cleanBuild)
-                {
-                    try
-                    {
-                        Functions.CleanBuildFiles();
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine("ERROR: " + ex.Message);
-                        ExitHeadless(2);
-                    }
-
-                    Console.WriteLine("Build files cleaned.");
-                    ExitHeadless(0);
-                }
-
-                if (buildRequested)
-                {
-                    try
-                    {
-                        bool success = await Functions.CreateBuild();
-                        if (!success)
-                        {
-                            Console.Error.WriteLine("ERROR: Build failed.");
-                            ExitHeadless(2);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine("ERROR: " + ex.Message);
-                        ExitHeadless(2);
-                    }
-
-                    Console.WriteLine("Build complete.");
-                    ExitHeadless(0);
-                }
-            }
+                await RunHeadlessAsync(migrateAssets, createPatches, cleanBuild, buildRequested, buildPlatform, graphicsStr);
 
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
             return 0;
@@ -222,5 +70,179 @@ namespace LADXHD_Migrater
                 .UsePlatformDetect()
                 .WithInterFont()
                 .LogToTrace();
+
+        private static void ShowHelp(Mono.Options.OptionSet opts)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                AttachConsole(ATTACH_PARENT_PROCESS);
+
+            Console.WriteLine();
+            Console.WriteLine("LADXHD Migrater");
+            Console.WriteLine("Usage: Migrater [options]");
+            Console.WriteLine();
+            Console.WriteLine("Options:");
+            opts.WriteOptionDescriptions(Console.Out);
+            Console.WriteLine();
+            Console.WriteLine("Exit codes: 0=Success, 1=Source assets missing, 2=Operation failed, 3=Invalid arguments");
+            Console.WriteLine();
+
+            ExitHeadless(0);
+        }
+
+        private static void SetNativePlatform()
+        {
+            Config.SelectedPlatform = Config.GetNativePlatform();
+            Config.SelectedGraphics = (Config.SelectedPlatform == Config.Platform.Windows)
+                ? Config.GraphicsAPI.DirectX
+                : Config.GraphicsAPI.OpenGL;
+        }
+
+        private static void ParsePlatform(string buildPlatform, string? graphicsStr)
+        {
+            Config.Platform platform = buildPlatform.ToLowerInvariant() switch
+            {
+                "windows"     => Config.Platform.Windows,
+                "android"     => Config.Platform.Android,
+                "linux-x86"   => Config.Platform.Linux_x64,
+                "linux-arm64" => Config.Platform.Linux_Arm64,
+                "macos-x86"   => Config.Platform.MacOS_x64,
+                "macos-arm64" => Config.Platform.MacOS_Arm64,
+                _ => throw new ArgumentException($"Invalid --build value '{buildPlatform}'. Valid values: windows, android, linux-x86, linux-arm64, macos-x86, macos-arm64")
+            };
+
+            Config.GraphicsAPI graphics;
+            if (graphicsStr != null)
+            {
+                graphics = graphicsStr.ToLowerInvariant() switch
+                {
+                    "directx" => Config.GraphicsAPI.DirectX,
+                    "opengl"  => Config.GraphicsAPI.OpenGL,
+                    _ => throw new ArgumentException($"Invalid --graphics value '{graphicsStr}'. Valid values: directx, opengl")
+                };
+                if (graphics == Config.GraphicsAPI.DirectX && platform != Config.Platform.Windows)
+                    throw new ArgumentException("--graphics directx is only supported on Windows. Use --graphics opengl for other platforms.");
+            }
+            else
+            {
+                graphics = (platform == Config.Platform.Windows) ? Config.GraphicsAPI.DirectX : Config.GraphicsAPI.OpenGL;
+            }
+
+            Config.SelectedPlatform = platform;
+            Config.SelectedGraphics = graphics;
+        }
+
+        private static async Task RunHeadlessAsync(bool migrateAssets, bool createPatches, bool cleanBuild, bool buildRequested, string? buildPlatform, string? graphicsStr)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                AttachConsole(ATTACH_PARENT_PROCESS);
+
+            Functions.HeadlessMode = true;
+            Config.Initialize();
+            BuildAvaloniaApp().SetupWithoutStarting();
+
+            if (buildRequested && buildPlatform != null)
+            {
+                try
+                {
+                    ParsePlatform(buildPlatform, graphicsStr);
+                }
+                catch (ArgumentException ex)
+                {
+                    Console.Error.WriteLine("ERROR: " + ex.Message);
+                    ExitHeadless(3);
+                }
+            }
+
+            if (migrateAssets)      RunMigrate();
+            if (createPatches)      RunCreatePatches();
+            if (cleanBuild)         RunCleanBuild();
+            if (buildRequested)     await RunBuildAsync();
+        }
+
+        private static void RunMigrate()
+        {
+            if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+            {
+                Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
+                ExitHeadless(1);
+            }
+
+            try
+            {
+                Functions.MigrateFiles();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("ERROR: " + ex.Message);
+                ExitHeadless(2);
+            }
+
+            Console.WriteLine("Migration complete.");
+            ExitHeadless(0);
+        }
+
+        private static void RunCreatePatches()
+        {
+            if (!Config.Orig_Content.TestPath() || !Config.Orig_Data.TestPath())
+            {
+                Console.Error.WriteLine("ERROR: assets_original/Content or assets_original/Data is missing.");
+                ExitHeadless(1);
+            }
+            if (!Config.Update_Content.TestPath() || !Config.Update_Data.TestPath())
+            {
+                Console.Error.WriteLine("ERROR: ladxhd_game_source_code Content or Data is missing.");
+                ExitHeadless(1);
+            }
+
+            try
+            {
+                Functions.CreatePatches();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("ERROR: " + ex.Message);
+                ExitHeadless(2);
+            }
+
+            Console.WriteLine("Patches created.");
+            ExitHeadless(0);
+        }
+
+        private static void RunCleanBuild()
+        {
+            try
+            {
+                Functions.CleanBuildFiles();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("ERROR: " + ex.Message);
+                ExitHeadless(2);
+            }
+
+            Console.WriteLine("Build files cleaned.");
+            ExitHeadless(0);
+        }
+
+        private static async Task RunBuildAsync()
+        {
+            try
+            {
+                bool success = await Functions.CreateBuild();
+                if (!success)
+                {
+                    Console.Error.WriteLine("ERROR: Build failed.");
+                    ExitHeadless(2);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("ERROR: " + ex.Message);
+                ExitHeadless(2);
+            }
+
+            Console.WriteLine("Build complete.");
+            ExitHeadless(0);
+        }
     }
 }

--- a/ladxhd_migrate_source_code/Program/Config.cs
+++ b/ladxhd_migrate_source_code/Program/Config.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace LADXHD_Migrater
 {
@@ -25,6 +26,14 @@ namespace LADXHD_Migrater
 
         public enum GraphicsAPI { DirectX, OpenGL }
         public static GraphicsAPI SelectedGraphics;
+
+        public static Platform GetNativePlatform()
+        {
+            bool isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
+            if (OperatingSystem.IsLinux()) return isArm64 ? Platform.Linux_Arm64 : Platform.Linux_x64;
+            if (OperatingSystem.IsMacOS()) return isArm64 ? Platform.MacOS_Arm64 : Platform.MacOS_x64;
+            return Platform.Windows;
+        }
 
         public static void Initialize()
         {

--- a/ladxhd_migrate_source_code/Program/DotNet.cs
+++ b/ladxhd_migrate_source_code/Program/DotNet.cs
@@ -12,6 +12,16 @@ namespace LADXHD_Migrater
         {
             if (!Config.Game_Source.TestPath()) return false;
 
+            if ((OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) &&
+                string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MGFXC_WINE_PATH")))
+            {
+                string url = OperatingSystem.IsMacOS()
+                    ? "https://tinyurl.com/mgfxc-macos"
+                    : "https://tinyurl.com/mgfxc-linux";
+                await Functions.Notify("Wine Not Configured", $"MGFXC_WINE_PATH environment variable is not set. Shader compilation will fail.\n\nSee {url}");
+                return false;
+            }
+
             try
             {
                 (string? buildFolder, string? csproj, string? framework, string? rid, string? profile, string? extra, string? exe) =

--- a/ladxhd_migrate_source_code/Program/DotNet.cs
+++ b/ladxhd_migrate_source_code/Program/DotNet.cs
@@ -146,7 +146,7 @@ namespace LADXHD_Migrater
             }
             catch (Exception ex)
             {
-                await OkayWindow.ShowAsync("Exception Caught", "Exception: " + ex.Message, 10);
+                await Functions.Notify("Exception Caught", "Exception: " + ex.Message, 10);
             }
 
             if (Config.SelectedPlatform == Platform.Windows)
@@ -221,7 +221,7 @@ namespace LADXHD_Migrater
                     string message = string.IsNullOrWhiteSpace(error) ? output : error;
                     if (message.Length > 500)
                         message = message.Substring(message.Length - 500);
-                    await OkayWindow.ShowAsync(errorTitle, message, 10);
+                    await Functions.Notify(errorTitle, message, 10);
                     return false;
                 }
             }

--- a/ladxhd_migrate_source_code/Program/DotNet.cs
+++ b/ladxhd_migrate_source_code/Program/DotNet.cs
@@ -44,7 +44,7 @@ namespace LADXHD_Migrater
                 string args = $"publish {csproj} -c Release -f {framework}";
                 if (!string.IsNullOrEmpty(rid)) args += $" -r {rid}";
                 if (!string.IsNullOrEmpty(extra)) args += $" {extra}";
-                args += $" -p:PublishProfile={profile}";
+                args += $" -p:PublishProfile={profile} --disable-build-servers -p:UsedAvaloniaProducts=";
 
                 if (!await RunProcess("dotnet", args, "Build Error")) return false;
 
@@ -75,7 +75,7 @@ namespace LADXHD_Migrater
             if (string.IsNullOrEmpty(rid) || string.IsNullOrEmpty(profile))
                 return true;
 
-            string args = $"publish LADXHD_Launcher.csproj -r {rid} -p:PublishProfile={profile}";
+            string args = $"publish LADXHD_Launcher.csproj -r {rid} -p:PublishProfile={profile} --disable-build-servers -p:UsedAvaloniaProducts=";
             return await RunProcess("dotnet", args, "Launcher Build Error", Config.Launcher_Source);
         }
 
@@ -89,14 +89,29 @@ namespace LADXHD_Migrater
                     FileName = executable,
                     Arguments = arguments,
                     UseShellExecute = false,
-                    RedirectStandardOutput = !Functions.HeadlessMode,
-                    RedirectStandardError = !Functions.HeadlessMode,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
                     CreateNoWindow = true
                 };
 
+                if (Functions.HeadlessMode)
+                {
+                    process.OutputDataReceived += (_, e) => { if (e.Data != null) Console.WriteLine(e.Data); };
+                    process.ErrorDataReceived  += (_, e) => { if (e.Data != null) Console.Error.WriteLine(e.Data); };
+                }
+
                 process.Start();
 
-                if (!Functions.HeadlessMode)
+                if (Functions.HeadlessMode)
+                {
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+                    process.WaitForExit();
+
+                    if (process.ExitCode != 0)
+                        return false;
+                }
+                else
                 {
                     string output = await process.StandardOutput.ReadToEndAsync();
                     string error = await process.StandardError.ReadToEndAsync();
@@ -110,12 +125,6 @@ namespace LADXHD_Migrater
                         await Functions.Notify(errorTitle, message, 10);
                         return false;
                     }
-                }
-                else
-                {
-                    process.WaitForExit();
-                    if (process.ExitCode != 0)
-                        return false;
                 }
             }
             return true;

--- a/ladxhd_migrate_source_code/Program/DotNet.cs
+++ b/ladxhd_migrate_source_code/Program/DotNet.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using static LADXHD_Migrater.Config;
 
@@ -9,167 +8,44 @@ namespace LADXHD_Migrater
 {
     internal class DotNet
     {
-        private static string WslPrefix(string wslPath) => $"export MGFXC_WINE_PATH={WinePath} && cd {wslPath} && dotnet";
-
-        private static string ToWslPath(string windowsPath)
-        {
-            string full = Path.GetFullPath(windowsPath);
-            string drive = full.Substring(0, 1).ToLower();
-            string rest = full.Substring(2).Replace('\\', '/');
-            return $"/mnt/{drive}{rest}";
-        }
-        private static string WinePath = GetWslWinePath();
-
-        private static string GetWslWinePath()
-        {
-            // Try to get the path to Wine which includes the username in WSL.
-            try
-            {
-                var p = Process.Start(new ProcessStartInfo("wsl", "echo $HOME")
-                {
-                    RedirectStandardOutput = true,
-                    CreateNoWindow = true,
-                    UseShellExecute = false
-                });
-                string? home = p?.StandardOutput.ReadLine()?.Trim();
-                p?.WaitForExit();
-                if (!string.IsNullOrEmpty(home))
-                    return home + "/.wine-mgfxc";
-            }
-            catch { }
-
-            // Fallback to lowercased Windows username if nothing is found.
-            return "/home/" + Environment.UserName.ToLower() + "/.wine-mgfxc";
-        }
-
         public async static Task<bool> BuildGame()
         {
-            string restoreArgs;
-            string publishArgs;
-
             if (!Config.Game_Source.TestPath()) return false;
 
             try
             {
-                if (Config.SelectedPlatform == Platform.Windows)
-                {
-                    if (!await RunProcess("dotnet", "restore", false, "Restore Error")) return false;
+                (string? buildFolder, string? csproj, string? framework, string? rid, string? profile, string? extra, string? exe) =
+                    (Config.SelectedPlatform, Config.SelectedGraphics) switch
+                    {
+                        (Platform.Windows, GraphicsAPI.DirectX) => ("Windows-DX", "ProjectZ.Desktop/ProjectZ.Desktop.csproj", "net8.0-windows", "win-x64", "FolderProfile_DX", "-p:EnableWindowsTargeting=true", "Link's Awakening DX HD.exe"),
+                        (Platform.Windows, GraphicsAPI.OpenGL) => ("Windows-GL", "ProjectZ.Desktop/ProjectZ.Desktop.csproj", "net8.0", "win-x64", "FolderProfile_GL", "-p:EnableWindowsTargeting=true", "Link's Awakening DX HD.exe"),
+                        (Platform.Android, _) => ("Android", "ProjectZ.Android/ProjectZ.Android.csproj", "net8.0-android", null, "FolderProfile_Android", null, "com.zelda.ladxhd-Signed.apk"),
+                        (Platform.Linux_x64, _) => ("Linux-x86_64","ProjectZ.Linux/ProjectZ.Linux.csproj", "net8.0", "linux-x64", "FolderProfile_Linux", null, "Link's Awakening DX HD"),
+                        (Platform.Linux_Arm64, _) => ("Linux-Arm64", "ProjectZ.Linux/ProjectZ.Linux.csproj", "net8.0", "linux-arm64", "FolderProfile_Linux_Arm", null, "Link's Awakening DX HD"),
+                        (Platform.MacOS_Arm64, _) => ("MacOS-Arm64", "ProjectZ.MacOS/ProjectZ.MacOS.csproj", "net8.0", "osx-arm64", "FolderProfile_MacOS", null, "Link's Awakening DX HD"),
+                        (Platform.MacOS_x64, _) => ("MacOS-x86_64", "ProjectZ.MacOS/ProjectZ.MacOS.csproj", "net8.0", "osx-x64", "FolderProfile_MacOS_x64", null, "Link's Awakening DX HD"),
+                        _ => (null, null, null, null, null, null, null)
+                    };
 
-                    if (Config.SelectedGraphics == GraphicsAPI.DirectX)
-                    {
-                        Config.Build_Path = Path.Combine(Config.Publish_Path, "Windows-DX");
-                        restoreArgs = "build ProjectZ.Desktop\\ProjectZ.Desktop.csproj -c Release -f net8.0-windows -r win-x64 --no-restore";
-                        publishArgs = "publish ProjectZ.Desktop\\ProjectZ.Desktop.csproj -c Release -f net8.0-windows -r win-x64 --no-restore -p:PublishProfile=FolderProfile_DX";
-                        if (!await RunProcess("dotnet", restoreArgs, false, "Build Error")) return false;
-                        if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                    }
-                    else if (Config.SelectedGraphics == GraphicsAPI.OpenGL)
-                    {
-                        Config.Build_Path = Path.Combine(Config.Publish_Path, "Windows-GL");
-                        restoreArgs = "build ProjectZ.Desktop\\ProjectZ.Desktop.csproj -c Release -f net8.0 -r win-x64 --no-restore";
-                        publishArgs = "publish ProjectZ.Desktop\\ProjectZ.Desktop.csproj -c Release -f net8.0 -r win-x64 --no-restore -p:PublishProfile=FolderProfile_GL";
-                        if (!await RunProcess("dotnet", restoreArgs, false, "Build Error")) return false;
-                        if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                    }
-                }
-                else if (Config.SelectedPlatform == Platform.Android)
-                {
-                    Config.Build_Path = Path.Combine(Config.Publish_Path, "Android");
-                    if (!await RunProcess("dotnet", "restore", false, "Restore Error")) return false;
-                    publishArgs = "publish ProjectZ.Android\\ProjectZ.Android.csproj -c Release -f net8.0-android --no-restore -p:PublishProfile=FolderProfile_Android";
-                    if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                }
-                else if (Config.SelectedPlatform == Platform.Linux_x64)
-                {
-                    Config.Build_Path = Path.Combine(Config.Publish_Path, "Linux-x86_64");
-                #if WINDOWS
-                    string prefix = WslPrefix(ToWslPath(Config.Game_Source));
-                    restoreArgs = $"bash -c \"{prefix} restore ProjectZ.Linux/ProjectZ.Linux.csproj\"";
-                    publishArgs = $"bash -c \"{prefix} publish ProjectZ.Linux/ProjectZ.Linux.csproj -c Release -f net8.0 -r linux-x64 --no-restore -p:PublishProfile=FolderProfile_Linux\"";
-                    if (!await RunProcess("wsl", restoreArgs, true, "Restore Error")) return false;
-                    if (!await RunProcess("wsl", publishArgs, true, "Build Error")) return false;
-                #else
-                    restoreArgs = "restore ProjectZ.Linux/ProjectZ.Linux.csproj";
-                    publishArgs = "publish ProjectZ.Linux/ProjectZ.Linux.csproj -c Release -f net8.0 -r linux-x64 --no-restore -p:PublishProfile=FolderProfile_Linux";
-                    if (!await RunProcess("dotnet", restoreArgs, false, "Restore Error")) return false;
-                    if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                #endif
-                }
-                else if (Config.SelectedPlatform == Platform.Linux_Arm64)
-                {
-                    Config.Build_Path = Path.Combine(Config.Publish_Path, "Linux-Arm64");
-                #if WINDOWS
-                    string prefix = WslPrefix(ToWslPath(Config.Game_Source));
-                    restoreArgs = $"bash -c \"{prefix} restore ProjectZ.Linux/ProjectZ.Linux.csproj\"";
-                    publishArgs = $"bash -c \"{prefix} publish ProjectZ.Linux/ProjectZ.Linux.csproj -c Release -f net8.0 -r linux-arm64 --no-restore -p:PublishProfile=FolderProfile_Linux_Arm\"";
-                    if (!await RunProcess("wsl", restoreArgs, true, "Restore Error")) return false;
-                    if (!await RunProcess("wsl", publishArgs, true, "Build Error")) return false;
-                #else
-                    restoreArgs = "restore ProjectZ.Linux/ProjectZ.Linux.csproj";
-                    publishArgs = "publish ProjectZ.Linux/ProjectZ.Linux.csproj -c Release -f net8.0 -r linux-arm64 --no-restore -p:PublishProfile=FolderProfile_Linux_Arm";
-                    if (!await RunProcess("dotnet", restoreArgs, false, "Restore Error")) return false;
-                    if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                #endif
-                }
-                else if (Config.SelectedPlatform == Platform.MacOS_Arm64)
-                {
-                    Config.Build_Path = Path.Combine(Config.Publish_Path, "MacOS-Arm64");
-                #if WINDOWS
-                    string prefix = WslPrefix(ToWslPath(Config.Game_Source));
-                    restoreArgs = $"bash -c \"{prefix} restore ProjectZ.MacOS/ProjectZ.MacOS.csproj\"";
-                    publishArgs = $"bash -c \"{prefix} publish ProjectZ.MacOS/ProjectZ.MacOS.csproj -c Release -f net8.0 -r osx-arm64 --no-restore -p:PublishProfile=FolderProfile_MacOS\"";
-                    if (!await RunProcess("wsl", restoreArgs, true, "Restore Error")) return false;
-                    if (!await RunProcess("wsl", publishArgs, true, "Build Error")) return false;
-                #else
-                    restoreArgs = "restore ProjectZ.MacOS/ProjectZ.MacOS.csproj";
-                    publishArgs = "publish ProjectZ.MacOS/ProjectZ.MacOS.csproj -c Release -f net8.0 -r osx-arm64 --no-restore -p:PublishProfile=FolderProfile_MacOS";
-                    if (!await RunProcess("dotnet", restoreArgs, false, "Restore Error")) return false;
-                    if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                #endif
-                }
-                else if (Config.SelectedPlatform == Platform.MacOS_x64)
-                {
-                    Config.Build_Path = Path.Combine(Config.Publish_Path, "MacOS-x86_64");
-                #if WINDOWS
-                    string prefix = WslPrefix(ToWslPath(Config.Game_Source));
-                    restoreArgs = $"bash -c \"{prefix} restore ProjectZ.MacOS/ProjectZ.MacOS.csproj\"";
-                    publishArgs = $"bash -c \"{prefix} publish ProjectZ.MacOS/ProjectZ.MacOS.csproj -c Release -f net8.0 -r osx-x64 --no-restore -p:PublishProfile=FolderProfile_MacOS_x64\"";
-                    if (!await RunProcess("wsl", restoreArgs, true, "Restore Error")) return false;
-                    if (!await RunProcess("wsl", publishArgs, true, "Build Error")) return false;
-                #else
-                    restoreArgs = "restore ProjectZ.MacOS/ProjectZ.MacOS.csproj";
-                    publishArgs = "publish ProjectZ.MacOS/ProjectZ.MacOS.csproj -c Release -f net8.0 -r osx-x64 --no-restore -p:PublishProfile=FolderProfile_MacOS_x64";
-                    if (!await RunProcess("dotnet", restoreArgs, false, "Restore Error")) return false;
-                    if (!await RunProcess("dotnet", publishArgs, false, "Build Error")) return false;
-                #endif
-                }
+                if (buildFolder == null) return false;
+
+                Config.Build_Path = Path.Combine(Config.Publish_Path, buildFolder);
+
+                string args = $"publish {csproj} -c Release -f {framework}";
+                if (!string.IsNullOrEmpty(rid)) args += $" -r {rid}";
+                if (!string.IsNullOrEmpty(extra)) args += $" {extra}";
+                args += $" -p:PublishProfile={profile}";
+
+                if (!await RunProcess("dotnet", args, "Build Error")) return false;
+
+                string exePath = Path.Combine(Config.Build_Path, exe!);
+                return exePath.TestPath();
             }
             catch (Exception ex)
             {
                 await Functions.Notify("Exception Caught", "Exception: " + ex.Message, 10);
+                return false;
             }
-
-            if (Config.SelectedPlatform == Platform.Windows)
-            {
-                string exePath = Path.Combine(Config.Build_Path, "Link's Awakening DX HD.exe");
-                return exePath.TestPath();
-            }
-            else if (Config.SelectedPlatform == Platform.Android)
-            {
-                string apkPath = Path.Combine(Config.Build_Path, "com.zelda.ladxhd-Signed.apk");
-                return apkPath.TestPath();
-            }
-            else if (Config.SelectedPlatform == Platform.Linux_x64 || Config.SelectedPlatform == Platform.Linux_Arm64)
-            {
-                string linuxBinPath = Path.Combine(Config.Build_Path, "Link's Awakening DX HD");
-                return linuxBinPath.TestPath();
-            }
-            else if (Config.SelectedPlatform == Platform.MacOS_Arm64 || Config.SelectedPlatform == Platform.MacOS_x64)
-            {
-                string macBinPath = Path.Combine(Config.Build_Path, "Link's Awakening DX HD");
-                return macBinPath.TestPath();
-            }
-            return false;
         }
 
         public async static Task<bool> BuildLauncher()
@@ -185,44 +61,51 @@ namespace LADXHD_Migrater
                 Platform.MacOS_Arm64 => ("osx-arm64","macOS-arm64"),
                 _                    => ("","")
             };
-            
-            if (string.IsNullOrEmpty(rid) || string.IsNullOrEmpty(profile)) 
+
+            if (string.IsNullOrEmpty(rid) || string.IsNullOrEmpty(profile))
                 return true;
 
-            string args = $"publish LADXHD_Launcher.csproj -r {rid} /p:PublishProfile={profile}";
-            return await RunProcess("dotnet", args, false, "Launcher Build Error", Config.Launcher_Source);
+            string args = $"publish LADXHD_Launcher.csproj -r {rid} -p:PublishProfile={profile}";
+            return await RunProcess("dotnet", args, "Launcher Build Error", Config.Launcher_Source);
         }
 
-        private async static Task<bool> RunProcess(string executable, string arguments, bool useWsl, string errorTitle, string workingDirectory = "")
+        private async static Task<bool> RunProcess(string executable, string arguments, string errorTitle, string workingDirectory = "")
         {
             using (Process process = new Process())
             {
                 process.StartInfo = new ProcessStartInfo
                 {
-                    // Use explicit workingDirectory if provided, otherwise fall back to existing logic.
-                    WorkingDirectory = useWsl ? "" : (string.IsNullOrEmpty(workingDirectory) ? Config.Game_Source : workingDirectory),
+                    WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? Config.Game_Source : workingDirectory,
                     FileName = executable,
                     Arguments = arguments,
                     UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
+                    RedirectStandardOutput = !Functions.HeadlessMode,
+                    RedirectStandardError = !Functions.HeadlessMode,
                     CreateNoWindow = true
                 };
 
                 process.Start();
 
-                string output = await process.StandardOutput.ReadToEndAsync();
-                string error  = await process.StandardError.ReadToEndAsync();
-
-                await process.WaitForExitAsync();
-
-                if (process.ExitCode != 0)
+                if (!Functions.HeadlessMode)
                 {
-                    string message = string.IsNullOrWhiteSpace(error) ? output : error;
-                    if (message.Length > 500)
-                        message = message.Substring(message.Length - 500);
-                    await Functions.Notify(errorTitle, message, 10);
-                    return false;
+                    string output = await process.StandardOutput.ReadToEndAsync();
+                    string error = await process.StandardError.ReadToEndAsync();
+                    await process.WaitForExitAsync();
+
+                    if (process.ExitCode != 0)
+                    {
+                        string message = string.IsNullOrWhiteSpace(error) ? output : error;
+                        if (message.Length > 500)
+                            message = message.Substring(message.Length - 500);
+                        await Functions.Notify(errorTitle, message, 10);
+                        return false;
+                    }
+                }
+                else
+                {
+                    process.WaitForExit();
+                    if (process.ExitCode != 0)
+                        return false;
                 }
             }
             return true;

--- a/ladxhd_migrate_source_code/Program/Functions.cs
+++ b/ladxhd_migrate_source_code/Program/Functions.cs
@@ -318,72 +318,71 @@ namespace LADXHD_Migrater
 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-        public async static Task CreateBuild()
+        public async static Task<bool> CreateBuild()
         {
-            // Try to build the game.
-            if (await DotNet.BuildGame())
+            if (!await DotNet.BuildGame())
+                return false;
+
+            string finalGamePath = "";
+            string publishFolder = Path.Combine(Config.BaseFolder, "~Publish").CreatePath();
+
+            if (Config.SelectedPlatform == Platform.Windows)
             {
-                // Stores where to move the result.
-                string finalGamePath = "";
-                string publishFolder = Path.Combine(Config.BaseFolder, "~Publish").CreatePath();
+                if (Config.SelectedGraphics == GraphicsAPI.DirectX)
+                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_windows_dx");
+                else if (Config.SelectedGraphics == GraphicsAPI.OpenGL)
+                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_windows_gl");
+            }
+            else if (Config.SelectedPlatform == Platform.Android)
+                finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_android");
+            
+            else if (Config.SelectedPlatform == Platform.Linux_x64)
+                finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_linux_x86_64");
+            
+            else if (Config.SelectedPlatform == Platform.Linux_Arm64)
+                finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_linux_arm64");
+            
+            else if (Config.SelectedPlatform == Platform.MacOS_Arm64)
+                finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_macos_arm64");
 
-                // If it succeeded, move the folder to the main folder.
-                if (Config.SelectedPlatform == Platform.Windows)
+            else if (Config.SelectedPlatform == Platform.MacOS_x64)
+                finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_macos_x86_64");
+
+            // Move the publish folder to the root directory.
+            Config.Build_Path.MovePath(finalGamePath, true);
+
+            // Remove the old publish folder if it's empty.
+            if (Config.Publish_Path.IsPathEmpty())
+                Config.Publish_Path.RemovePath();
+
+            // Build the matching launcher and copy it into the game output folder.
+            if (await DotNet.BuildLauncher())
+            {
+                string launcherPublish = Path.Combine(Config.Launcher_Source, "~Publish");
+                if (launcherPublish.TestPath())
                 {
-                    if (Config.SelectedGraphics == GraphicsAPI.DirectX)
-                        finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_windows_dx");
-                    else if (Config.SelectedGraphics == GraphicsAPI.OpenGL)
-                        finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_windows_gl");
-                }
-                else if (Config.SelectedPlatform == Platform.Android)
-                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_android");
-                
-                else if (Config.SelectedPlatform == Platform.Linux_x64)
-                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_linux_x86_64");
-                
-                else if (Config.SelectedPlatform == Platform.Linux_Arm64)
-                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_linux_arm64");
-                
-                else if (Config.SelectedPlatform == Platform.MacOS_Arm64)
-                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_macos_arm64");
-
-                else if (Config.SelectedPlatform == Platform.MacOS_x64)
-                    finalGamePath = Path.Combine(publishFolder, "zelda_ladxhd_build_macos_x86_64");
-
-                // Move the publish folder to the root directory.
-                Config.Build_Path.MovePath(finalGamePath, true);
-
-                // Remove the old publish folder if it's empty.
-                if (Config.Publish_Path.IsPathEmpty())
-                    Config.Publish_Path.RemovePath();
-
-                // Build the matching launcher and copy it into the game output folder.
-                if (await DotNet.BuildLauncher())
-                {
-                    string launcherPublish = Path.Combine(Config.Launcher_Source, "~Publish");
-                    if (launcherPublish.TestPath())
+                    // Copy launcher files into the already-moved game folder.
+                    foreach (string file in launcherPublish.GetFiles("*", true))
                     {
-                        // Copy launcher files into the already-moved game folder.
-                        foreach (string file in launcherPublish.GetFiles("*", true))
-                        {
-                            FileItem item = new FileItem(file);
-                            string dest = Path.Combine(finalGamePath, item.Name);
-                            File.Copy(file, dest, true);
-                        }
-                        launcherPublish.RemovePath();
+                        FileItem item = new FileItem(file);
+                        string dest = Path.Combine(finalGamePath, item.Name);
+                        File.Copy(file, dest, true);
                     }
-                }
-                // Remove any leftover files that are unnecessary.
-                HashSet<string> junkFiles = new HashSet<string> { "nfd.lib", "nfd.pdb", "_Microsoft.Android.Resource.Designer.dll" };
-                foreach (string file in finalGamePath.GetFiles("*"))
-                {
-                    FileItem item = new FileItem(file);
-                    if (junkFiles.Contains(item.Name))
-                    {
-                        item.FullName.RemovePath();
-                    }
+                    launcherPublish.RemovePath();
                 }
             }
+            // Remove any leftover files that are unnecessary.
+            HashSet<string> junkFiles = new HashSet<string> { "nfd.lib", "nfd.pdb", "_Microsoft.Android.Resource.Designer.dll" };
+            foreach (string file in finalGamePath.GetFiles("*"))
+            {
+                FileItem item = new FileItem(file);
+                if (junkFiles.Contains(item.Name))
+                {
+                    item.FullName.RemovePath();
+                }
+            }
+            
+            return true;
         }
     }
 }

--- a/ladxhd_migrate_source_code/Program/Functions.cs
+++ b/ladxhd_migrate_source_code/Program/Functions.cs
@@ -12,6 +12,14 @@ namespace LADXHD_Migrater
     {
         public static bool HeadlessMode;
 
+        public static async Task Notify(string title, string message, int timeoutSeconds = 0, bool altSound = false)
+        {
+            if (HeadlessMode)
+                Console.WriteLine($"[{title}] {message}");
+            else
+                await OkayWindow.ShowAsync(title, message, timeoutSeconds, altSound);
+        }
+
 /*-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
         FILE MAPPING CODE : NOT ALL FILES AND PATCHES ARE 1:1 FROM ORIGINAL GAME VERSION. NEW FILES NEED A "BASE" TO BE CREATED FROM USING A PATCH

--- a/ladxhd_migrate_source_code/UserInterface/MainWindow.axaml.cs
+++ b/ladxhd_migrate_source_code/UserInterface/MainWindow.axaml.cs
@@ -10,8 +10,16 @@ namespace LADXHD_Migrater
         public MainWindow()
         {
             InitializeComponent();
-            ComboBox_Platform.SelectedIndex = 0;
-            ComboBox_API.SelectedIndex = 0;
+            ComboBox_Platform.SelectedIndex = Config.GetNativePlatform() switch
+            {
+                Config.Platform.Windows     => 0,
+                Config.Platform.Android     => 1,
+                Config.Platform.Linux_x64   => 2,
+                Config.Platform.Linux_Arm64 => 3,
+                Config.Platform.MacOS_x64   => 4,
+                Config.Platform.MacOS_Arm64 => 5,
+                _ => 0
+            };
         }
 
         public void EnableComponents(bool toggle)


### PR DESCRIPTION
This adds all remaining functions to headless mode (creating patches, cleaning up build artifacts, creating builds), and adds support for building the game on all platforms.

Game builds have been simplified by:
* Fully removing WSL usage. .NET 8 and MonoGame fully support cross-platform builds. Actually, when building from Windows, it is a lot faster to avoid WSL + Wine (@BigheadSMZ I see you are using WSL in your publish.bat, I'd encourage you to just build from Windows to accelerate the process considerably).
* Merging `restore` and `publish` into a single step, since we aren't using multi-step builds (Docker images, CI/CD shared cache, etc) and both steps are always executed unconditionally, just letting `publish` take care of restoring automatically simplifies things.

Making headless mode work on Windows has been quite a nightmare. WinExe apps do everything in their power to not be terminal-friendly, so a bunch of time has gone into trying to get something functional. The main current issue is a WinExe won't wait until completing its work to yield control back to the terminal. To use the migrater in automated flows that need to wait until completion on Windows, what I've found to work is using:

```
Start-Process -Wait '.\Migrater.exe' -ArgumentList '--build'
``` 

Just like the Patcher, the Migrater will now default to the platform where it's been executed for builds, but supports building for all the rest.