### PR TITLE
Patcher: strip version from executable names.

### DIFF
--- a/.github/workflows/build-migrater.yml
+++ b/.github/workflows/build-migrater.yml
@@ -64,12 +64,12 @@ jobs:
         shell: bash
         run: |
           mv ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/Migrater${{ matrix.ext_src }} \
-            ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD_Migrater${{ matrix.ext }}
+            ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD-Migrater${{ matrix.ext }}
 
       - name: Sign binary (macOS)
         if: runner.os == 'macOS'
         env:
-          APP_PATH: ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD_Migrater${{ matrix.ext }}
+          APP_PATH: ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD-Migrater${{ matrix.ext }}
         run: |
           codesign --force --deep --sign - "$APP_PATH"
           codesign --verify --verbose "$APP_PATH"
@@ -77,7 +77,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: LADXHD_Migrater_${{ matrix.profile }}-${{ github.run_id }}
+          name: LADXHD-Migrater-${{ matrix.profile }}-${{ github.run_id }}
           path: |
             ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/
             !ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/nfd.lib

--- a/.github/workflows/build-migrater.yml
+++ b/.github/workflows/build-migrater.yml
@@ -16,27 +16,22 @@ jobs:
           - profile: macOS-arm64
             rid: osx-arm64
             runner: macos-latest
-            ext_src: '.app'
             ext: '.app'
           - profile: macOS-x64
             rid: osx-x64
             runner: macos-latest
-            ext_src: '.app'
             ext: '.app'
           - profile: Linux-arm64
             rid: linux-arm64
             runner: ubuntu-latest
-            ext_src: ''
-            ext: '.bin'
+            ext: ''
           - profile: Linux-x64
             rid: linux-x64
             runner: ubuntu-latest
-            ext_src: ''
-            ext: '.bin'
+            ext: ''
           - profile: Windows
             rid: win-x64
             runner: windows-latest
-            ext_src: '.exe'
             ext: '.exe'
 
     steps:
@@ -63,7 +58,7 @@ jobs:
       - name: Rename migrater file
         shell: bash
         run: |
-          mv ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/Migrater${{ matrix.ext_src }} \
+          mv ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/Migrater${{ matrix.ext }} \
             ladxhd_migrate_source_code/~Publish/${{ matrix.profile }}/LADXHD-Migrater${{ matrix.ext }}
 
       - name: Sign binary (macOS)

--- a/.github/workflows/build-patcher.yml
+++ b/.github/workflows/build-patcher.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: LADXHD.Patcher.v${{ steps.get_version.outputs.version }}_${{ matrix.profile }}-${{ github.run_id }}
+          name: LADXHD-Patcher-v${{ steps.get_version.outputs.version }}-${{ matrix.profile }}-${{ github.run_id }}
           path: |
             ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/
             !ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/nfd.lib

--- a/.github/workflows/build-patcher.yml
+++ b/.github/workflows/build-patcher.yml
@@ -16,27 +16,22 @@ jobs:
           - profile: macOS-arm64
             rid: osx-arm64
             runner: macos-latest
-            ext_src: '.app'
             ext: '.app'
           - profile: macOS-x64
             rid: osx-x64
             runner: macos-latest
-            ext_src: '.app'
             ext: '.app'
           - profile: Linux-arm64
             rid: linux-arm64
             runner: ubuntu-latest
-            ext_src: ''
-            ext: '.bin'
+            ext: ''
           - profile: Linux-x64
             rid: linux-x64
             runner: ubuntu-latest
-            ext_src: ''
-            ext: '.bin'
+            ext: ''
           - profile: Windows
             rid: win-x64
             runner: windows-latest
-            ext_src: '.exe'
             ext: '.exe'
 
     steps:
@@ -70,7 +65,7 @@ jobs:
       - name: Rename patcher file
         shell: bash
         run: |
-          mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext_src }} \
+          mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext }} \
             ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD-Patcher${{ matrix.ext }}
 
       - name: Sign binary (macOS)

--- a/.github/workflows/build-patcher.yml
+++ b/.github/workflows/build-patcher.yml
@@ -71,12 +71,12 @@ jobs:
         shell: bash
         run: |
           mv ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/Patcher${{ matrix.ext_src }} \
-            ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD.Patcher.v${{ steps.get_version.outputs.version }}${{ matrix.ext }}
+            ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD-Patcher${{ matrix.ext }}
 
       - name: Sign binary (macOS)
         if: runner.os == 'macOS'
         env:
-          APP_PATH: ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD.Patcher.v${{ steps.get_version.outputs.version }}${{ matrix.ext }}
+          APP_PATH: ladxhd_patcher_source_code/~Publish/${{ matrix.profile }}/LADXHD-Patcher${{ matrix.ext }}
         run: |
           codesign --force --deep --sign - "$APP_PATH"
           codesign --verify --verbose "$APP_PATH"

--- a/ladxhd_patcher_source_code/publish/fix-macos-permissions.command
+++ b/ladxhd_patcher_source_code/publish/fix-macos-permissions.command
@@ -9,11 +9,11 @@ Link's Awakening DX HD - macOS Permissions Fix
 
 EOF
 
-PATCHER_APP=$(find . -name "LADXHD.Patcher.v*.app" 2>/dev/null | head -n 1)
+PATCHER_APP="LADXHD-Patcher.app"
 
-if [ -z "$PATCHER_APP" ]; then
-    echo "Error: Could not find a file matching 'LADXHD.Patcher.v*.app' in this folder."
-    exit 1
+if [ ! -d "$PATCHER_APP" ]; then
+	echo "Error: Could not find 'LADXHD-Patcher.app' in this folder."
+	exit 1
 fi
 
 echo "Found: $PATCHER_APP"


### PR DESCRIPTION
Linux setups keep struggling with anything that resembles an extension, since the distributed zip already contains the version number, let's remove any extension-like bit from the executable name for compatibility.

Since we're at it, I'm standardized the naming of distributed files to use dashes as the part separators (more common in executable names in the industry), rather than the current mix of dots, underscores, and dashes.

Fixes #861